### PR TITLE
feat: Add minimal SeedRL-style example for SWE-bench

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -1,0 +1,127 @@
+# Claude Coding Guidelines for ARES
+
+This document provides coding guidelines for Claude when working on the ARES codebase.
+
+## Commenting Philosophy
+
+### Comments Should Explain WHY, Not WHAT
+
+The most valuable comments explain the reasoning behind a decision, not what the code is doing. Code should be self-explanatory through clear variable names, function names, and structure.
+
+**Good Examples:**
+```python
+# Group by temperature to avoid mixing generation params across actors
+grouped_requests = group_by_temperature(requests)
+
+# SWE-Bench requires a fresh container per instance to ensure isolation
+if not self._test_spec.is_remote_image:
+    raise NotImplementedError("Need to implement local image support.")
+
+# Queue mediates requests to allow linear code flow while exposing LLM interactions as observations/actions
+llm_client = QueueMediatedLLMClient(q=asyncio.Queue())
+```
+
+**Bad Examples:**
+```python
+# Build an LLMResponse using the helper function
+response = build_llm_response(data)
+
+# Call the helper function
+result = helper_function(input)
+
+# Create a list
+my_list = []
+```
+
+### When to Comment
+
+- **WHY**: Explain architectural decisions, non-obvious design choices, or business logic
+- **HOW**: For complex algorithms or non-trivial operations, explain the approach
+- **NOT WHAT**: Avoid describing what the code obviously does
+
+### Complex Code
+
+For complex operations, explain HOW it works:
+
+```python
+# Parse test results by applying repo-specific log parser, then evaluate against
+# FAIL_TO_PASS and PASS_TO_PASS criteria to determine resolution status
+log_parser = MAP_REPO_TO_PARSER[repo]
+test_status_map = log_parser(test_output, specs)
+report = get_eval_tests_report(test_status_map, eval_instance)
+```
+
+## General Coding Guidelines
+
+### Type Hints
+
+- Use type hints for function parameters and return values
+- Use `collections.abc` types for abstract collections (`Sequence`, `Mapping`, etc.)
+- Prefer specific types over generic ones when possible
+
+### Async/Await
+
+- This codebase uses async extensively
+- Always use `async def` and `await` for I/O operations
+- Use `asyncio.create_task()` for concurrent operations
+
+### Documentation Strings
+
+- Use docstrings for classes and public functions
+- Follow Google-style docstring format with Args, Returns, and Raises sections
+- Include usage examples in class docstrings when helpful
+
+### Code Organization
+
+- Keep related functionality together in modules
+- Use dataclasses for data structures (`@dataclasses.dataclass`)
+- Use Pydantic models for external data validation (`pydantic.BaseModel`)
+
+### Logging
+
+- Use Python's `logging` module with module-level loggers
+- Include contextual IDs (`id(self)`, `id(container)`) for tracking in concurrent operations
+- Use appropriate log levels: DEBUG for detailed flow, INFO for key operations, WARNING/ERROR for issues
+
+### Error Handling
+
+- Raise descriptive exceptions with clear messages
+- Use runtime checks for state validation (e.g., "Container has not been created before...")
+- Add assertion messages for invariants: `assert condition, "explanation"`
+
+### Naming Conventions
+
+- Use descriptive names that make the code self-documenting
+- Private methods and attributes: prefix with `_`
+- Constants: `UPPER_SNAKE_CASE`
+- Classes: `PascalCase`
+- Functions/variables: `snake_case`
+
+## Project-Specific Patterns
+
+### Container Management
+
+- Containers are async context managers
+- Always start containers before use
+- Use factory patterns for container creation
+
+### Code Agents
+
+- Code agents use the dm_env async spec
+- LLM interactions are mediated through queues
+- Agents run as asyncio tasks
+
+### Testing
+
+- Test specs come from SWE-bench harness
+- Each SWE-bench instance requires a separate container
+- Use repo-specific parsers for test output
+
+## TODOs
+
+Use TODO comments for:
+- Missing implementations
+- Future improvements
+- Known issues that need addressing
+
+Format: `# TODO: Description of what needs to be done.`

--- a/examples/02_local_llm.py
+++ b/examples/02_local_llm.py
@@ -9,12 +9,7 @@ Example usage:
 """
 
 import asyncio
-import time
-import uuid
 
-import openai.types.chat.chat_completion
-import openai.types.chat.chat_completion_message
-import openai.types.completion_usage
 import transformers
 
 from ares.environments import swebench_env
@@ -65,30 +60,12 @@ async def main():
             # We remove special tokens, such as the end of turn token.
             output_text = tokenizer.decode(outputs[0][num_input_tokens:], skip_special_tokens=True)
 
-            # Since an action is a chat completion response, we have to build one here.
-            action = llm_clients.LLMResponse(
-                chat_completion_response=openai.types.chat.chat_completion.ChatCompletion(
-                    id=str(uuid.uuid4()),
-                    choices=[
-                        openai.types.chat.chat_completion.Choice(
-                            message=openai.types.chat.chat_completion_message.ChatCompletionMessage(
-                                content=output_text,
-                                role="assistant",
-                            ),
-                            finish_reason="stop",
-                            index=0,
-                        )
-                    ],
-                    created=int(time.time()),
-                    model="Qwen/Qwen2.5-3B-Instruct",
-                    object="chat.completion",
-                    usage=openai.types.completion_usage.CompletionUsage(
-                        prompt_tokens=num_input_tokens,
-                        completion_tokens=num_output_tokens,
-                        total_tokens=num_input_tokens + num_output_tokens,
-                    ),
-                ),
-                cost=0.0,
+            # Build an LLMResponse using the helper function.
+            action = llm_clients.build_openai_compatible_llm_response(
+                output_text=output_text,
+                num_input_tokens=num_input_tokens,
+                num_output_tokens=num_output_tokens,
+                model="Qwen/Qwen2.5-3B-Instruct",
             )
 
             # Print the observation and action.

--- a/examples/03_seedrl_swebench.py
+++ b/examples/03_seedrl_swebench.py
@@ -1,0 +1,452 @@
+"""Minimal SeedRL-style architecture for SWE-bench using asyncio.
+
+This example demonstrates a distributed RL architecture with:
+- Multiple async actors running SweBenchEnv episodes in parallel
+- A centralized Learner that handles model inference
+- Queue-based communication between actors and learner
+- A minimal C51 distributional value head (structure only, not trained)
+
+This is a demo of the SeedRL architecture pattern, not a full trainer.
+
+Example usage:
+
+    1. Make sure you have examples dependencies installed
+       `uv sync --group examples`
+    2. Run the example
+       `uv run -m examples.03_seedrl_swebench`
+"""
+
+import asyncio
+import dataclasses
+import time
+import uuid
+from typing import Any
+
+import openai.types.chat.chat_completion
+import openai.types.chat.chat_completion_message
+import openai.types.completion_usage
+import torch
+import torch.nn as nn
+import transformers
+
+from ares.environments import swebench_env
+from ares.llms import llm_clients
+
+
+# ============================================================================
+# Value Head (C51 Distributional Critic)
+# ============================================================================
+
+
+class C51ValueHead(nn.Module):
+    """Minimal C51-style distributional value head.
+
+    This demonstrates where a value head would attach to model hidden states.
+    In a full implementation, this would be trained alongside the policy to
+    predict value distributions for RL algorithms like IMPALA or R2D2.
+
+    Args:
+        hidden_size: Size of the input hidden states from the transformer
+        num_atoms: Number of atoms in the categorical distribution (C51 default: 51)
+        v_min: Minimum value of the support
+        v_max: Maximum value of the support
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 1536,  # Qwen2.5-1.5B hidden size
+        num_atoms: int = 51,
+        v_min: float = 0.0,
+        v_max: float = 1.0,
+    ):
+        super().__init__()
+        self.num_atoms = num_atoms
+        self.register_buffer("support", torch.linspace(v_min, v_max, num_atoms))
+
+        # Project hidden states to atom logits
+        self.value_head = nn.Sequential(
+            nn.Linear(hidden_size, 512),
+            nn.ReLU(),
+            nn.Linear(512, num_atoms),
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> dict[str, torch.Tensor]:
+        """Forward pass of the value head.
+
+        Args:
+            hidden_states: Transformer hidden states, shape [batch, seq_len, hidden_size]
+
+        Returns:
+            Dictionary with:
+                - logits: Raw logits over atoms, shape [batch, seq_len, num_atoms]
+                - probs: Softmax probabilities, shape [batch, seq_len, num_atoms]
+                - value: Expected value (dot product of probs and support)
+        """
+        # Take the last token's hidden state for value prediction
+        last_hidden = hidden_states[:, -1, :]  # [batch, hidden_size]
+
+        logits = self.value_head(last_hidden)  # [batch, num_atoms]
+        probs = torch.softmax(logits, dim=-1)
+
+        # Expected value: E[Z] = sum(p_i * z_i)
+        value = (probs * self.support).sum(dim=-1, keepdim=True)  # [batch, 1]
+
+        return {
+            "logits": logits,
+            "probs": probs,
+            "value": value,
+        }
+
+
+# ============================================================================
+# Inference Request & Response
+# ============================================================================
+
+
+@dataclasses.dataclass
+class InferenceRequest:
+    """Request from an actor to the learner for inference."""
+    actor_id: int
+    request: llm_clients.LLMRequest
+    response_future: asyncio.Future[llm_clients.LLMResponse]
+
+
+# ============================================================================
+# Learner (Centralized Inference)
+# ============================================================================
+
+
+class Learner:
+    """Centralized learner that handles model inference for all actors.
+
+    In a full SeedRL implementation, the learner would also:
+    - Receive trajectories from actors
+    - Update model parameters via gradient descent
+    - Periodically sync updated weights back to actors
+
+    For this demo, we focus on the inference path.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "Qwen/Qwen2.5-1.5B-Instruct",
+        device: str | None = None,
+    ):
+        self.model_name = model_name
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+
+        print(f"[Learner] Loading model {model_name} on {self.device}...")
+        self.tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)
+        self.model = transformers.AutoModelForCausalLM.from_pretrained(model_name)
+        self.model.to(self.device)
+        self.model.eval()  # Inference mode
+
+        # Attach the C51 value head (not trained, just for demonstration)
+        hidden_size = self.model.config.hidden_size
+        self.value_head = C51ValueHead(hidden_size=hidden_size).to(self.device)
+        print(f"[Learner] Attached C51 value head with {hidden_size}-dim inputs")
+
+        self.request_queue: asyncio.Queue[InferenceRequest] = asyncio.Queue()
+        self.inference_task: asyncio.Task[None] | None = None
+
+        # Stats
+        self.total_requests = 0
+        self.total_tokens_generated = 0
+
+    async def start(self) -> None:
+        """Start the inference loop."""
+        print("[Learner] Starting inference loop...")
+        self.inference_task = asyncio.create_task(self._inference_loop())
+
+    async def stop(self) -> None:
+        """Stop the inference loop."""
+        if self.inference_task:
+            self.inference_task.cancel()
+            try:
+                await self.inference_task
+            except asyncio.CancelledError:
+                pass
+        print(f"[Learner] Stopped. Processed {self.total_requests} requests, "
+              f"generated {self.total_tokens_generated} tokens.")
+
+    async def request_inference(self, actor_id: int, request: llm_clients.LLMRequest) -> llm_clients.LLMResponse:
+        """Submit an inference request and await the response.
+
+        Args:
+            actor_id: ID of the requesting actor
+            request: LLMRequest containing messages
+
+        Returns:
+            LLMResponse with the model's generated text
+        """
+        response_future: asyncio.Future[llm_clients.LLMResponse] = asyncio.Future()
+        inference_request = InferenceRequest(
+            actor_id=actor_id,
+            request=request,
+            response_future=response_future,
+        )
+        await self.request_queue.put(inference_request)
+        return await response_future
+
+    async def _inference_loop(self) -> None:
+        """Main inference loop that processes requests from the queue.
+
+        In a production system, this would:
+        - Batch multiple requests together for efficiency
+        - Use dynamic batching with padding/truncation
+        - Handle variable-length sequences
+
+        For this demo, we process requests sequentially.
+        """
+        print("[Learner] Inference loop running...")
+
+        while True:
+            try:
+                # Get next request (blocks until available)
+                req = await self.request_queue.get()
+
+                # Run inference in a thread to avoid blocking the event loop
+                response = await asyncio.to_thread(self._run_inference, req)
+
+                # Send response back to the actor
+                req.response_future.set_result(response)
+
+                self.total_requests += 1
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                print(f"[Learner] Error in inference loop: {e}")
+                if not req.response_future.done():
+                    req.response_future.set_exception(e)
+
+    def _run_inference(self, req: InferenceRequest) -> llm_clients.LLMResponse:
+        """Run inference on a single request (blocking call, runs in thread pool).
+
+        Args:
+            req: InferenceRequest from an actor
+
+        Returns:
+            LLMResponse with generated text and value head output
+        """
+        # Tokenize the chat messages
+        inputs = self.tokenizer.apply_chat_template(
+            req.request.messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+        ).to(self.device)
+
+        # Generate completion
+        with torch.no_grad():
+            outputs = self.model.generate(
+                **inputs,
+                max_new_tokens=2048,
+                temperature=req.request.temperature or 1.0,
+                do_sample=True if req.request.temperature else False,
+            )
+
+            # Demonstrate value head usage:
+            # Get hidden states for the last input token
+            # (In a real trainer, you'd do this on full trajectories)
+            model_outputs = self.model(
+                input_ids=inputs["input_ids"],
+                attention_mask=inputs["attention_mask"],
+                output_hidden_states=True,
+            )
+            last_hidden_states = model_outputs.hidden_states[-1]  # Last layer
+            value_output = self.value_head(last_hidden_states)
+
+            # Print value head output shape once for demonstration
+            if self.total_requests == 0:
+                print(f"[Learner] Value head output shapes:")
+                print(f"  - logits: {value_output['logits'].shape}")
+                print(f"  - probs: {value_output['probs'].shape}")
+                print(f"  - value: {value_output['value'].shape}")
+                print(f"  - estimated value: {value_output['value'].item():.4f}")
+
+        # Decode output
+        num_input_tokens = inputs["input_ids"].shape[-1]
+        num_output_tokens = outputs[0].shape[-1] - num_input_tokens
+        output_text = self.tokenizer.decode(
+            outputs[0][num_input_tokens:],
+            skip_special_tokens=True,
+        )
+
+        self.total_tokens_generated += num_output_tokens
+
+        # Wrap in OpenAI-compatible response
+        response = llm_clients.LLMResponse(
+            chat_completion_response=openai.types.chat.chat_completion.ChatCompletion(
+                id=str(uuid.uuid4()),
+                choices=[
+                    openai.types.chat.chat_completion.Choice(
+                        message=openai.types.chat.chat_completion_message.ChatCompletionMessage(
+                            content=output_text,
+                            role="assistant",
+                        ),
+                        finish_reason="stop",
+                        index=0,
+                    )
+                ],
+                created=int(time.time()),
+                model=self.model_name,
+                object="chat.completion",
+                usage=openai.types.completion_usage.CompletionUsage(
+                    prompt_tokens=num_input_tokens,
+                    completion_tokens=num_output_tokens,
+                    total_tokens=num_input_tokens + num_output_tokens,
+                ),
+            ),
+            cost=0.0,
+        )
+
+        return response
+
+
+# ============================================================================
+# Actor (Environment Runner)
+# ============================================================================
+
+
+class Actor:
+    """Actor that runs SweBenchEnv episodes and requests inference from the learner.
+
+    In a full SeedRL implementation, actors would:
+    - Collect full trajectories (obs, action, reward, done)
+    - Send trajectories to the learner for training
+    - Periodically fetch updated model weights from the learner
+
+    For this demo, we just run the environment loop.
+    """
+
+    def __init__(
+        self,
+        actor_id: int,
+        learner: Learner,
+        task: swebench_env.SwebenchTask,
+        max_steps: int = 5,
+    ):
+        self.actor_id = actor_id
+        self.learner = learner
+        self.task = task
+        self.max_steps = max_steps
+
+    async def run_episode(self) -> dict[str, Any]:
+        """Run a single episode of the environment.
+
+        Returns:
+            Episode statistics (steps, reward, etc.)
+        """
+        print(f"[Actor {self.actor_id}] Starting episode on task {self.task.instance_id}")
+
+        # Create environment for this task
+        async with swebench_env.SweBenchEnv(tasks=[self.task]) as env:
+            ts = await env.reset()
+            step_count = 0
+
+            while not ts.last() and step_count < self.max_steps:
+                # Request inference from the centralized learner
+                action = await self.learner.request_inference(self.actor_id, ts.observation)
+
+                # Print step info
+                _print_step(self.actor_id, step_count, ts.observation, action)
+
+                # Step the environment
+                ts = await env.step(action)
+                step_count += 1
+
+            print(f"[Actor {self.actor_id}] Episode finished: {step_count} steps, "
+                  f"reward={ts.reward:.2f}")
+
+            return {
+                "actor_id": self.actor_id,
+                "steps": step_count,
+                "reward": ts.reward,
+                "task_id": self.task.instance_id,
+            }
+
+
+# ============================================================================
+# Main Orchestration
+# ============================================================================
+
+
+async def main():
+    """Main entry point for the SeedRL demo.
+
+    This demonstrates the architecture:
+    1. Start a centralized Learner with a shared model
+    2. Create N actors that run environments in parallel
+    3. Actors request inference from the Learner via a queue
+    4. Learner processes requests and returns actions
+    """
+    # Configuration
+    n_actors = 1  # Start with 1, easily parameterize to scale up
+    model_name = "Qwen/Qwen2.5-1.5B-Instruct"
+
+    print("=" * 80)
+    print("SeedRL-style SWE-bench Demo")
+    print("=" * 80)
+    print(f"Actors: {n_actors}")
+    print(f"Model: {model_name}")
+    print("=" * 80)
+
+    # Load tasks
+    all_tasks = swebench_env.swebench_verified_tasks()
+    selected_tasks = [all_tasks[0]]  # Use first task for demo
+
+    print(f"\nTask: {selected_tasks[0].instance_id}")
+    print(f"Repo: {selected_tasks[0].repo}")
+    print("-" * 80)
+
+    # Initialize centralized learner
+    learner = Learner(model_name=model_name)
+    await learner.start()
+
+    try:
+        # Create actors
+        actors = [
+            Actor(actor_id=i, learner=learner, task=selected_tasks[0], max_steps=5)
+            for i in range(n_actors)
+        ]
+
+        # Run actors in parallel (for this demo with 1 actor, it's just one task)
+        # In a full system with n_actors > 1, this would run multiple episodes concurrently
+        results = await asyncio.gather(*[actor.run_episode() for actor in actors])
+
+        # Print summary
+        print("\n" + "=" * 80)
+        print("Episode Results")
+        print("=" * 80)
+        for result in results:
+            print(f"Actor {result['actor_id']}: {result['steps']} steps, "
+                  f"reward={result['reward']:.2f}")
+        print("=" * 80)
+
+    finally:
+        # Clean up
+        await learner.stop()
+
+
+def _print_step(
+    actor_id: int,
+    step: int,
+    observation: llm_clients.LLMRequest | None,
+    action: llm_clients.LLMResponse,
+) -> None:
+    """Helper to print step information."""
+    action_str = str(action.chat_completion_response.choices[0].message.content)[:100]
+    observation_str = "No observation"
+    if observation is not None:
+        observation_content = list(observation.messages)[-1].get("content", "")
+        observation_str = str(observation_content)[:100]
+
+    print(f"\n[Actor {actor_id} | Step {step}]")
+    print(f"Observation: {observation_str}")
+    print(f"Action: {action_str}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/ares/llms/llm_clients.py
+++ b/src/ares/llms/llm_clients.py
@@ -2,8 +2,13 @@
 
 from collections.abc import Iterable
 import dataclasses
+import time
+import uuid
 from typing import Any, Protocol
 
+import openai.types.chat.chat_completion
+import openai.types.chat.chat_completion_message
+import openai.types.completion_usage
 from openai.types.chat import chat_completion as chat_completion_type
 from openai.types.chat import chat_completion_message_param
 
@@ -27,3 +32,60 @@ class LLMResponse:
 
 class LLMClient(Protocol):
     async def __call__(self, request: LLMRequest) -> LLMResponse: ...
+
+
+def build_openai_compatible_llm_response(
+    output_text: str,
+    num_input_tokens: int,
+    num_output_tokens: int,
+    model: str,
+    cost: float = 0.0,
+) -> LLMResponse:
+    """Build an LLMResponse from raw generation outputs in OpenAI-compatible format.
+
+    This helper constructs a complete OpenAI ChatCompletion-compatible LLMResponse
+    from basic generation outputs. It's useful when working with local models or
+    non-OpenAI endpoints that need to conform to the ARES LLMResponse interface.
+
+    Args:
+        output_text: The generated text content from the model.
+        num_input_tokens: Number of tokens in the input/prompt.
+        num_output_tokens: Number of tokens in the generated output.
+        model: Model identifier string (e.g., "Qwen/Qwen2.5-3B-Instruct").
+        cost: Cost of the API call in USD. Defaults to 0.0 for local models.
+
+    Returns:
+        LLMResponse: A complete response object with OpenAI-compatible structure.
+
+    Example:
+        >>> response = build_openai_compatible_llm_response(
+        ...     output_text="Hello, world!",
+        ...     num_input_tokens=10,
+        ...     num_output_tokens=3,
+        ...     model="Qwen/Qwen2.5-3B-Instruct",
+        ... )
+    """
+    return LLMResponse(
+        chat_completion_response=openai.types.chat.chat_completion.ChatCompletion(
+            id=str(uuid.uuid4()),
+            choices=[
+                openai.types.chat.chat_completion.Choice(
+                    message=openai.types.chat.chat_completion_message.ChatCompletionMessage(
+                        content=output_text,
+                        role="assistant",
+                    ),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            created=int(time.time()),
+            model=model,
+            object="chat.completion",
+            usage=openai.types.completion_usage.CompletionUsage(
+                prompt_tokens=num_input_tokens,
+                completion_tokens=num_output_tokens,
+                total_tokens=num_input_tokens + num_output_tokens,
+            ),
+        ),
+        cost=cost,
+    )


### PR DESCRIPTION
# Generated description
```mermaid
graph LR
main_("main"):::added
Learner_start_("Learner.start"):::added
Actor_run_episode_("Actor.run_episode"):::added
Learner_request_inference_("Learner.request_inference"):::added
Learner_run_batched_inference_("Learner._run_batched_inference"):::added
Learner_run_inference_("Learner._run_inference"):::added
build_openai_compatible_llm_response_("build_openai_compatible_llm_response"):::added
C51ValueHead_forward_("C51ValueHead.forward"):::added
main_ -- "Now starts Learner inference loop before spawning actors." --> Learner_start_
main_ -- "Main now gathers Actor.run_episode tasks for parallel episodes." --> Actor_run_episode_
Actor_run_episode_ -- "Actor requests LLMResponse each step via Learner.request_inference." --> Learner_request_inference_
Learner_run_batched_inference_ -- "Falls back to single-request path when batch size equals one." --> Learner_run_inference_
Learner_run_batched_inference_ -- "Uses helper to construct OpenAI-compatible responses per batch element." --> build_openai_compatible_llm_response_
Learner_run_batched_inference_ -- "Invokes value head on batched hidden states for diagnostics." --> C51ValueHead_forward_
Learner_run_inference_ -- "Wraps decoded generation into OpenAI-style LLMResponse via helper." --> build_openai_compatible_llm_response_
Learner_run_inference_ -- "Runs value head on last-token hidden states to estimate value." --> C51ValueHead_forward_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Adds a minimal SeedRL-style architecture example for the <code>ares</code> module's LLM integration, demonstrating a centralized <code>Learner</code> for batched inference and distributed <code>Actor</code>s for running SWE-bench environment episodes. Introduces a new helper function, <code>build_openai_compatible_llm_response</code>, to standardize LLM response creation across examples and components.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/10?tool=ast&topic=SeedRL+Example>SeedRL Example</a>
        </td><td>Implements a minimal SeedRL-style architecture for the SWE-bench environment, featuring a centralized <code>Learner</code> for batched LLM inference and distributed <code>Actor</code>s to run environment episodes. This includes a new helper function <code>build_openai_compatible_llm_response</code> to standardize LLM responses, which is also retrofitted into an existing example.<details><summary>Modified files (3)</summary><ul><li>examples/02_local_llm.py</li>
<li>examples/03_seedrl_swebench.py</li>
<li>src/ares/llms/llm_clients.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>joshua.greaves@gmail.com</td><td>Add-example-2-local-LL...</td><td>January 09, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/10?tool=ast&topic=Coding+Guidelines>Coding Guidelines</a>
        </td><td>Adds a new <code>Claude.md</code> document outlining coding guidelines for the ARES codebase, focusing on commenting philosophy, general coding practices, and project-specific patterns.<details><summary>Modified files (1)</summary><ul><li>Claude.md</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/withmartian/ares/10?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SWE-bench example demonstrating async inference batching with value estimation
  * Improved LLM response construction for consistent output handling

* **Documentation**
  * Added comprehensive coding standards and guidelines documentation

* **Refactor**
  * Simplified LLM response creation across examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->