### PR TITLE
fix: Update minimal_loop example to use valid model name

### DIFF
--- a/examples/01_minimal_loop.py
+++ b/examples/01_minimal_loop.py
@@ -19,7 +19,8 @@ from ares.llms import llm_clients
 
 async def main():
     # Create an LLM client using the ChatCompletionCompatibleLLMClient
-    agent = chat_completions_compatible.ChatCompletionCompatibleLLMClient(model="openai/gpt-5-mini")
+    # Users can choose different models (e.g., "openai/gpt-4o-mini", "anthropic/claude-3-5-sonnet-20241022")
+    agent = chat_completions_compatible.ChatCompletionCompatibleLLMClient(model="openai/gpt-4o-mini")
 
     # Load all SWE-bench verified tasks
     all_tasks = swebench_env.swebench_verified_tasks()


### PR DESCRIPTION
# User description
## Summary
- Changed model name from invalid `openai/gpt-5-mini` to valid `openai/gpt-4o-mini` in examples/01_minimal_loop.py
- Added comment explaining that users can choose different models

## Test plan
- [x] Verified Python syntax with `python3 -m compileall examples/`
- [x] Code changes are minimal and localized to the model configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description
Updates the <code>ares</code> module's minimal example by changing the <code>ChatCompletionCompatibleLLMClient</code> model from an invalid <code>openai/gpt-5-mini</code> to a valid <code>openai/gpt-4o-mini</code>. Ensures the tutorial example for the observation-action loop uses a functional LLM client configuration.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>joshua.greaves@gmail.com</td><td>Add-example-2-local-LL...</td><td>January 09, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/withmartian/ares/16?tool=ast>(Baz)</a>.