### PR TITLE
Update pyproject.toml for PyPI listing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,11 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/ares"]
+
 [project]
-name = "ares"
+name = "martian-ares"
 version = "0.0.1"
 authors = [
     {name = "Joshua Greaves", email = "josh@withmartian.com"},
@@ -13,6 +16,7 @@ authors = [
 description = "Agentic Research and Evaluation Suite"
 readme = "README.md"
 requires-python = ">=3.12"
+license = {file = "LICENSE"}
 dependencies = [
     "daytona>=0.125.0",
     "docker>=7.1.0",
@@ -36,11 +40,17 @@ dependencies = [
     "torch>=2.9.1",
 ]
 
+[project.urls]
+Homepage = "https://github.com/withmartian/ares"
+Repository = "https://github.com/withmartian/ares"
+
 [dependency-groups]
 dev = [
     "pyright>=1.1.406",
     "ruff>=0.14.1",
     "pytest>=8.0.0",
+    "hatchling>=1.28.0",
+    "twine>=6.2.0",
 ]
 examples = [
     "transformers>=4.57.3",


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the project configuration to facilitate distribution on PyPI by renaming the package and defining build targets. Enhances the <code>pyproject.toml</code> metadata with license information, repository URLs, and necessary development tools for packaging.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/38?tool=ast&topic=Build+Configuration>Build Configuration</a>
        </td><td>Defines the <code>tool.hatch.build.targets.wheel</code> package path and adds <code>hatchling</code> and <code>twine</code> to the development dependency group to support the build and upload process.<details><summary>Modified files (1)</summary><ul><li>pyproject.toml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>joshua.greaves@gmail.com</td><td>chore-Configure-pyrigh...</td><td>January 19, 2026</td></tr>
<tr><td>ryanscais3@gmail.com</td><td>Add-DM-Env-Interface-3</td><td>December 18, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/38?tool=ast&topic=PyPI+Distribution>PyPI Distribution</a>
        </td><td>Configures the <code>pyproject.toml</code> file for PyPI publication by updating the package name to <code>martian-ares</code> and adding metadata such as <code>license</code> and <code>project.urls</code>.<details><summary>Modified files (1)</summary><ul><li>pyproject.toml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>joshua.greaves@gmail.com</td><td>chore-Configure-pyrigh...</td><td>January 19, 2026</td></tr>
<tr><td>ryanscais3@gmail.com</td><td>Add-DM-Env-Interface-3</td><td>December 18, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/withmartian/ares/38?tool=ast>(Baz)</a>.