### PR TITLE
Add selector notation for getting subsets of presets

### DIFF
--- a/src/ares/presets.py
+++ b/src/ares/presets.py
@@ -43,6 +43,10 @@ class SwebenchVerifiedMiniSWESpec:
         """Create SWE-bench Verified environment with mini-swe-agent."""
         all_tasks = swebench_env.swebench_verified_tasks()
         selected_tasks = selector(all_tasks)
+
+        if not selected_tasks:
+            raise ValueError("Task selector produced no tasks.")
+
         return swebench_env.SweBenchEnv(
             tasks=selected_tasks,
             container_factory=container_factory,

--- a/src/ares/registry_test.py
+++ b/src/ares/registry_test.py
@@ -170,9 +170,9 @@ def test_clear_registry():
 
 
 def test_parse_selector_no_selector():
-    """Test parsing preset name without selector."""
-    preset_name, selector = registry._parse_selector("test-preset")
-    assert preset_name == "test-preset"
+    """Test parsing preset ID without selector."""
+    preset_id, selector = registry._parse_selector("test-preset")
+    assert preset_id == "test-preset"
     assert isinstance(selector, registry.SliceSelector)
     assert selector.start is None
     assert selector.end is None
@@ -180,16 +180,16 @@ def test_parse_selector_no_selector():
 
 def test_parse_selector_single_index():
     """Test parsing single index selector."""
-    preset_name, selector = registry._parse_selector("test-preset:5")
-    assert preset_name == "test-preset"
+    preset_id, selector = registry._parse_selector("test-preset:5")
+    assert preset_id == "test-preset"
     assert isinstance(selector, registry.IndexSelector)
     assert selector.index == 5
 
 
 def test_parse_selector_slice():
     """Test parsing slice selector."""
-    preset_name, selector = registry._parse_selector("test-preset:0:10")
-    assert preset_name == "test-preset"
+    preset_id, selector = registry._parse_selector("test-preset:0:10")
+    assert preset_id == "test-preset"
     assert isinstance(selector, registry.SliceSelector)
     assert selector.start == 0
     assert selector.end == 10
@@ -197,8 +197,8 @@ def test_parse_selector_slice():
 
 def test_parse_selector_slice_start_only():
     """Test parsing slice with start only (e.g., :5:)."""
-    preset_name, selector = registry._parse_selector("test-preset:5:")
-    assert preset_name == "test-preset"
+    preset_id, selector = registry._parse_selector("test-preset:5:")
+    assert preset_id == "test-preset"
     assert isinstance(selector, registry.SliceSelector)
     assert selector.start == 5
     assert selector.end is None
@@ -206,8 +206,8 @@ def test_parse_selector_slice_start_only():
 
 def test_parse_selector_slice_end_only():
     """Test parsing slice with end only (e.g., ::10)."""
-    preset_name, selector = registry._parse_selector("test-preset::10")
-    assert preset_name == "test-preset"
+    preset_id, selector = registry._parse_selector("test-preset::10")
+    assert preset_id == "test-preset"
     assert isinstance(selector, registry.SliceSelector)
     assert selector.start is None
     assert selector.end == 10
@@ -215,8 +215,8 @@ def test_parse_selector_slice_end_only():
 
 def test_parse_selector_shard():
     """Test parsing shard selector."""
-    preset_name, selector = registry._parse_selector("test-preset@2/8")
-    assert preset_name == "test-preset"
+    preset_id, selector = registry._parse_selector("test-preset@2/8")
+    assert preset_id == "test-preset"
     assert isinstance(selector, registry.ShardSelector)
     assert selector.shard_index == 2
     assert selector.total_shards == 8


### PR DESCRIPTION
# User description
Do not submit before #40 .

This PR adds a selector syntax for presets in ARES:

- `ares.make("sbv-mswea")` - returns env with 500 tasks.
- `ares.make("sbv-mswea:0")` - returns env with the first task from SBV.
- `ares.make("sbv-mswea:10:20")` - returns env with 10 tasks, starting at index 10.
- `ares.make("sbv-mswea@2/8")` - returns 3rd of 8 shards (note 0-indexing).

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
make_("make"):::modified
parse_selector_("_parse_selector"):::added
IndexSelector_("IndexSelector"):::added
SliceSelector_("SliceSelector"):::added
ShardSelector_("ShardSelector"):::added
EnvironmentSpec_get_env_("EnvironmentSpec.get_env"):::modified
TaskSelector_("TaskSelector"):::added
SwebenchVerifiedMiniSWESpec_get_env_("SwebenchVerifiedMiniSWESpec.get_env"):::modified
make_ -- "Parses preset_id selector, enabling task selection syntax." --> parse_selector_
parse_selector_ -- "Constructs IndexSelector for single-index selection." --> IndexSelector_
parse_selector_ -- "Creates SliceSelector for start:end task ranges." --> SliceSelector_
parse_selector_ -- "Creates ShardSelector to evenly distribute tasks across shards." --> ShardSelector_
make_ -- "Passes parsed selector, container_factory, tracker into get_env." --> EnvironmentSpec_get_env_
EnvironmentSpec_get_env_ -- "Adds TaskSelector parameter to select subset of tasks." --> TaskSelector_
SwebenchVerifiedMiniSWESpec_get_env_ -- "Applies selector to swebench_verified_tasks, validates non-empty selection." --> TaskSelector_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Implements a task selector syntax for environment presets, enabling users to request specific subsets of tasks via indices, slices, or sharding. Updates the <code>registry</code> and <code>make</code> functions to parse these selectors and apply them during environment instantiation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/41?tool=ast&topic=Preset+Integration>Preset Integration</a>
        </td><td>Updates the <code>SwebenchVerifiedMiniSWESpec</code> and the base <code>EnvironmentSpec</code> protocol to accept and apply a <code>selector</code> when creating an environment.<details><summary>Modified files (2)</summary><ul><li>src/ares/presets.py</li>
<li>src/ares/registry.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bot@rowanassistant.com</td><td>feat-Add-preset-regist...</td><td>January 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/41?tool=ast&topic=Task+Selection+Logic>Task Selection Logic</a>
        </td><td>Introduces the <code>TaskSelector</code> protocol and concrete implementations (<code>IndexSelector</code>, <code>SliceSelector</code>, <code>ShardSelector</code>) along with a parser for the new string syntax in <code>registry.py</code>.<details><summary>Modified files (2)</summary><ul><li>src/ares/registry.py</li>
<li>src/ares/registry_test.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bot@rowanassistant.com</td><td>feat-Add-preset-regist...</td><td>January 22, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/withmartian/ares/41?tool=ast>(Baz)</a>.