### PR TITLE
Add @register_env decorator for preset registration

### DIFF
--- a/src/ares/registry_test.py
+++ b/src/ares/registry_test.py
@@ -580,31 +580,33 @@ def test_register_env_decorator_invalid_name():
             return "invalid"
 
 
-def test_register_env_decorator_metadata():
-    """Test that decorator correctly stores metadata."""
+def test_register_env_decorator_defaults():
+    """Test that decorator uses function name and docstring as defaults."""
 
-    @registry.register_env(
-        name="test-decorator-metadata",
-        description="Custom description for testing metadata",
-        num_tasks=999,
-    )
-    def create_test_env(
+    @registry.register_env(num_tasks=42)
+    def my_test_environment(
         *,
         selector: registry.TaskSelector,
         container_factory: containers.ContainerFactory,
         tracker: stat_tracker.StatTracker | None = None,
-    ) -> None:
-        """Test environment factory."""
-        del selector, container_factory, tracker  # Unused in test
-        return None
+    ) -> dict[str, Any]:
+        """A test environment for validating defaults."""
+        return {
+            "selector": selector,
+            "container_factory": container_factory,
+            "tracker": tracker,
+        }
 
-    # Get the registered spec and verify metadata
-    spec = registry._REGISTRY["test-decorator-metadata"]
+    # Verify preset is registered with function name
+    assert "my_test_environment" in registry._list_presets()
+
+    # Verify info uses function name and docstring
+    spec = registry._REGISTRY["my_test_environment"]
     env_info = spec.get_info()
 
-    assert env_info.name == "test-decorator-metadata"
-    assert env_info.description == "Custom description for testing metadata"
-    assert env_info.num_tasks == 999
+    assert env_info.name == "my_test_environment"
+    assert env_info.description == "A test environment for validating defaults."
+    assert env_info.num_tasks == 42
 
     # Clean up
-    registry.unregister_preset("test-decorator-metadata")
+    registry.unregister_preset("my_test_environment")


### PR DESCRIPTION
This commit adds a new decorator @register_env() that provides syntactic sugar for registering environment presets without manually creating spec classes.

The decorator:
- Takes parameters: name, description, num_tasks
- Wraps a function matching the EnvironmentSpec.get_env() signature
- Auto-generates an EnvironmentSpec implementation
- Registers it with the global registry
- Returns the original function for direct use

Example usage:
@register_env(
    name="my-dataset",
    description="My custom dataset",
    num_tasks=100,
)
def create_env(*, selector, container_factory, tracker=None):
    # Create and return environment
    return MyEnvironment(...)

The decorated function can still be called directly and the preset works with all existing registry features (make(), info(), selectors).

Added comprehensive tests covering:
- Basic registration and metadata
- Integration with make() and info()
- Selector syntax (index, slice, shard)
- Decorated function can be called directly
- Error handling (duplicate names, invalid characters)

Fixes #42