### PR TITLE
Add mswea license header

### DIFF
--- a/src/ares/code_agents/mini_swe_agent.py
+++ b/src/ares/code_agents/mini_swe_agent.py
@@ -1,3 +1,9 @@
+# Original code: https://github.com/SWE-agent/mini-swe-agent/blob/main/src/minisweagent/agents/default.py
+# Copyright (c) 2025 Kilian A. Lieret and Carlos E. Jimenez
+# Licensed under the MIT License.
+#
+# Modifications Copyright (c) 2026 Martian
+
 """A Code Agent wrapping the mini-swe-agent.
 
 Last checked: Nov 15, 2025


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adds a license header to the <code>mini_swe_agent.py</code> file to acknowledge the original source from the mini-swe-agent repository and specify Martian's modifications under the MIT License. This ensures proper attribution for the code agent component.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bot@rowanassistant.com</td><td>feat-Add-preset-regist...</td><td>January 22, 2026</td></tr>
<tr><td>sarvanithin</td><td>Remove-torch-from-core...</td><td>January 20, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/withmartian/ares/49?tool=ast>(Baz)</a>.