### PR TITLE
Change docs dependency group to optional dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,8 +104,8 @@ Before submitting a PR:
 To build and view the docs locally:
 
 ```bash
-uv sync --group docs
-cd docs && uv run --group docs make html
+uv sync --extra docs
+cd docs && uv run --extra docs make html
 ```
 
 and open the resulting `docs/build/html/index.html` file in your browser.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,11 @@ dependencies = [
 tensorboard = ["tensorboard>=2.20.0", "torch>=2.9.1"]
 llamacpp = ["llama-cpp-python>=0.3.16"]
 eval-viz = ["rich>=13.7.0", "textual>=1.0.0"]
+docs = [
+    "sphinx>=7.0.0",
+    "sphinx-rtd-theme>=2.0.0",
+    "sphinx-autodoc-typehints>=1.25.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/withmartian/ares"
@@ -61,11 +66,6 @@ examples = [
     "textual>=1.0.0",
     "tqdm>=4.66.0",
     "simple-parsing>=0.1.8",
-]
-docs = [
-    "sphinx>=7.0.0",
-    "sphinx-rtd-theme>=2.0.0",
-    "sphinx-autodoc-typehints>=1.25.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the documentation dependency configuration by moving it from a dependency group to an optional dependency in the project metadata. Modifies the contribution guide to ensure developers use the correct installation flags for building documentation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/56?tool=ast&topic=Docs+Instructions>Docs Instructions</a>
        </td><td>Updates the local documentation build instructions to use the <code>--extra</code> flag instead of <code>--group</code> when running <code>uv</code> commands.<details><summary>Modified files (1)</summary><ul><li>CONTRIBUTING.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ryanscais3@gmail.com</td><td>Add-initial-docs-52</td><td>January 28, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>docs-Add-contributing-...</td><td>January 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/56?tool=ast&topic=Dependency+Config>Dependency Config</a>
        </td><td>Relocates the <code>docs</code> dependency list from <code>dependency-groups</code> to <code>project.optional-dependencies</code> within <code>pyproject.toml</code>.<details><summary>Modified files (1)</summary><ul><li>pyproject.toml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ryanscais3@gmail.com</td><td>Add-initial-docs-52</td><td>January 28, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Remove-swebench-env-fo...</td><td>January 28, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/withmartian/ares/56?tool=ast>(Baz)</a>.