### PR TITLE
Fix Docker authentication errors and add anonymous pull support

### DIFF
--- a/examples/01_sequential_eval_with_local_llm.py
+++ b/examples/01_sequential_eval_with_local_llm.py
@@ -14,6 +14,10 @@ Prerequisites:
 
     - Install docker & make sure the daemon is running.
     - Install dependencies: `uv sync --group examples`
+    - If you see Docker authentication errors (e.g., "email must be verified"):
+        * RECOMMENDED: Set DOCKER_SKIP_AUTH=true to use anonymous pulls (no account needed)
+        * Or run `docker logout` to clear stored credentials
+        * Or verify your email at https://hub.docker.com/settings/general
 
 Example usage:
 

--- a/src/ares/config.py
+++ b/src/ares/config.py
@@ -45,5 +45,16 @@ class _Config(pydantic_settings.BaseSettings):
     daytona_auto_stop_interval: int = 30  # Minutes.
     daytona_delete_on_stop: bool = True
 
+    # Docker registry configuration (optional).
+    # If set, ARES will attempt to authenticate with the Docker registry before builds.
+    docker_registry_username: str = ""
+    docker_registry_password: str = ""
+    docker_registry_url: str = ""  # Empty string means Docker Hub (default registry).
+
+    # Set to true to skip Docker Hub authentication entirely and use anonymous pulls.
+    # This is useful if you don't have a Docker Hub account or don't want to verify your email.
+    # Note: Anonymous pulls are rate-limited to 100 pulls per 6 hours per IP address.
+    docker_skip_auth: bool = False
+
 
 CONFIG = _Config()  # type: ignore

--- a/src/ares/containers/docker.py
+++ b/src/ares/containers/docker.py
@@ -3,7 +3,9 @@
 import asyncio
 import dataclasses
 import functools
+import hashlib
 import io
+import logging
 import pathlib
 import tarfile
 from typing import cast
@@ -12,7 +14,142 @@ import docker
 import docker.errors
 import docker.models.containers
 
+from ares import config
 from ares.containers import containers
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DockerBuildError(RuntimeError):
+    """Raised when Docker image build or container start fails."""
+
+    pass
+
+
+# Cache: maps (dockerfile_path, dockerfile_hash) -> image_id
+# This avoids rebuilding the same Dockerfile repeatedly across environment resets.
+_DOCKERFILE_IMAGE_CACHE: dict[tuple[str, str], str] = {}
+
+
+def _compute_dockerfile_hash(dockerfile_path: pathlib.Path) -> str:
+    """Compute a hash of the Dockerfile contents for cache keying.
+
+    Args:
+        dockerfile_path: Path to the Dockerfile or its parent directory.
+
+    Returns:
+        SHA256 hash of the Dockerfile contents.
+    """
+    # Handle both file path and directory path
+    dockerfile_file = dockerfile_path / "Dockerfile" if dockerfile_path.is_dir() else dockerfile_path
+    content = dockerfile_file.read_bytes()
+    return hashlib.sha256(content).hexdigest()[:16]  # Use first 16 chars for brevity
+
+
+def _get_cached_image(dockerfile_path: pathlib.Path) -> str | None:
+    """Check if we have a cached image for this Dockerfile.
+
+    Args:
+        dockerfile_path: Path to the Dockerfile or its parent directory.
+
+    Returns:
+        Cached image ID if found, None otherwise.
+    """
+    try:
+        dockerfile_hash = _compute_dockerfile_hash(dockerfile_path)
+        cache_key = (str(dockerfile_path.resolve()), dockerfile_hash)
+        return _DOCKERFILE_IMAGE_CACHE.get(cache_key)
+    except Exception as e:
+        _LOGGER.debug("Error checking image cache: %s", e)
+        return None
+
+
+def _cache_image(dockerfile_path: pathlib.Path, image_id: str) -> None:
+    """Cache an image ID for a Dockerfile.
+
+    Args:
+        dockerfile_path: Path to the Dockerfile or its parent directory.
+        image_id: The built image ID.
+    """
+    try:
+        dockerfile_hash = _compute_dockerfile_hash(dockerfile_path)
+        cache_key = (str(dockerfile_path.resolve()), dockerfile_hash)
+        _DOCKERFILE_IMAGE_CACHE[cache_key] = image_id
+        _LOGGER.debug("Cached image %s for %s (hash: %s)", image_id, dockerfile_path, dockerfile_hash)
+    except Exception as e:
+        _LOGGER.debug("Error caching image: %s", e)
+
+
+def _clear_docker_credentials() -> None:
+    """Clear stored Docker credentials to allow anonymous pulls.
+
+    This removes the auth configuration from ~/.docker/config.json for Docker Hub,
+    allowing Docker to make unauthenticated requests (which don't require email verification).
+    """
+    import json
+
+    docker_config_path = pathlib.Path.home() / ".docker" / "config.json"
+    if not docker_config_path.exists():
+        _LOGGER.debug("No Docker config file found at %s", docker_config_path)
+        return
+
+    try:
+        with open(docker_config_path) as f:
+            docker_config = json.load(f)
+
+        # Check if there are any auths to clear
+        if docker_config.get("auths"):
+            # Clear the auths for Docker Hub
+            docker_hub_keys = [k for k in docker_config["auths"] if "docker.io" in k or "index.docker.io" in k]
+            if docker_hub_keys:
+                for key in docker_hub_keys:
+                    del docker_config["auths"][key]
+                with open(docker_config_path, "w") as f:
+                    json.dump(docker_config, f, indent=2)
+                _LOGGER.info("Cleared Docker Hub credentials from %s to enable anonymous pulls", docker_config_path)
+    except Exception as e:
+        _LOGGER.warning("Failed to clear Docker credentials: %s", e)
+
+
+def _ensure_docker_login(client: docker.DockerClient) -> None:
+    """Attempt Docker registry login if credentials are configured.
+
+    This is a no-op if no credentials are set in config or if docker_skip_auth is True.
+
+    Args:
+        client: The Docker client to authenticate.
+
+    Raises:
+        DockerBuildError: If authentication fails.
+    """
+    cfg = config.CONFIG
+
+    # If skip_auth is enabled, clear any stored credentials to ensure anonymous pulls work
+    if cfg.docker_skip_auth:
+        _LOGGER.debug("DOCKER_SKIP_AUTH is enabled, clearing any stored Docker credentials.")
+        _clear_docker_credentials()
+        return
+
+    if not cfg.docker_registry_username or not cfg.docker_registry_password:
+        _LOGGER.debug("No Docker registry credentials configured, skipping programmatic login.")
+        return
+
+    registry = cfg.docker_registry_url or "https://index.docker.io/v1/"
+    _LOGGER.debug("Attempting Docker login to %s as %s", registry, cfg.docker_registry_username)
+
+    try:
+        client.login(
+            username=cfg.docker_registry_username,
+            password=cfg.docker_registry_password,
+            registry=registry,
+        )
+        _LOGGER.info("Docker login successful for user: %s", cfg.docker_registry_username)
+    except docker.errors.APIError as e:
+        raise DockerBuildError(
+            f"Docker login failed for user '{cfg.docker_registry_username}'.\n"
+            f"Check your DOCKER_REGISTRY_USERNAME and DOCKER_REGISTRY_PASSWORD environment variables.\n"
+            f"Original error: {e}"
+        ) from e
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -32,35 +169,99 @@ class DockerContainer(containers.Container):
             raise RuntimeError("Failed to connect to Docker daemon; is docker running?") from e
 
     async def start(self, env: dict[str, str] | None = None) -> None:
-        """Start the container."""
+        """Start the container.
+
+        Raises:
+            DockerBuildError: If image build or container start fails.
+            ValueError: If neither image nor dockerfile_path is specified.
+        """
+        # Attempt Docker login if credentials are configured
+        _ensure_docker_login(self._client)
+
         if self.image is None:
             if self.dockerfile_path is None:
                 raise ValueError("Must specify one of image or dockerfile_path")
 
             dockerfile_path = pathlib.Path(self.dockerfile_path)
-            # TODO: Some kind of cache for dockerfile directory to avoid
-            #       rebuilding same image over and over again?
-            image_obj, _ = await asyncio.to_thread(
-                self._client.images.build,
-                path=dockerfile_path.parent.as_posix(),
-                tag=self.name,
-            )
-            self.image = image_obj.id
-            assert self.image is not None, f"Image ID is None for container {self.name}"
 
-        # TODO: Work out why this cast is necessary.
-        self._container = cast(
-            docker.models.containers.Container,
-            await asyncio.to_thread(
-                self._client.containers.run,
-                image=self.image,
-                name=self.name,
-                # Ensure the container stays running.
-                command="tail -f /dev/null",
-                detach=True,
-                environment=env,
-            ),
-        )
+            # Check cache first to avoid rebuilding the same Dockerfile
+            cached_image = _get_cached_image(dockerfile_path)
+            if cached_image is not None:
+                _LOGGER.info("Using cached image %s for %s", cached_image, dockerfile_path)
+                self.image = cached_image
+            else:
+                _LOGGER.debug("Building image from Dockerfile: %s", dockerfile_path)
+                try:
+                    image_obj, _ = await asyncio.to_thread(
+                        self._client.images.build,
+                        path=dockerfile_path.parent.as_posix(),
+                        tag=self.name,
+                    )
+                except docker.errors.BuildError as e:
+                    error_msg = str(e)
+                    if "email must be verified" in error_msg.lower():
+                        raise DockerBuildError(
+                            f"Docker Hub requires email verification for your account.\n\n"
+                            f"Solutions (choose one):\n"
+                            f"  1. RECOMMENDED: Set DOCKER_SKIP_AUTH=true to use anonymous pulls "
+                            f"(no account needed)\n"
+                            f"  2. Verify your email at https://hub.docker.com/settings/general\n"
+                            f"  3. Run 'docker logout' in your terminal to use anonymous pulls\n\n"
+                            f"Original error: {error_msg}"
+                        ) from e
+                    elif "authentication required" in error_msg.lower():
+                        raise DockerBuildError(
+                            f"Docker authentication failed while building image.\n"
+                            f"This typically means Docker Hub requires you to log in or verify your email.\n\n"
+                            f"Solutions (choose one):\n"
+                            f"  1. Set DOCKER_SKIP_AUTH=true to use anonymous pulls (no account needed)\n"
+                            f"  2. Run 'docker login' in your terminal\n"
+                            f"  3. Set DOCKER_REGISTRY_USERNAME and DOCKER_REGISTRY_PASSWORD env vars\n\n"
+                            f"Original error: {error_msg}"
+                        ) from e
+                    elif "pull access denied" in error_msg.lower():
+                        raise DockerBuildError(
+                            f"Docker pull access denied.\n"
+                            f"The base image may not exist or requires authentication.\n"
+                            f"Check that the base image in your Dockerfile is correct and accessible.\n\n"
+                            f"Original error: {error_msg}"
+                        ) from e
+                    else:
+                        raise DockerBuildError(
+                            f"Docker build failed: {error_msg}\nCheck the Dockerfile at: {dockerfile_path}"
+                        ) from e
+                except docker.errors.APIError as e:
+                    raise DockerBuildError(
+                        f"Docker API error during build: {e}\nIs the Docker daemon running? Try: docker info"
+                    ) from e
+
+                image_id = image_obj.id
+                assert image_id is not None, f"Image ID is None for container {self.name}"
+                self.image = image_id
+                _cache_image(dockerfile_path, image_id)
+                _LOGGER.debug("Image built successfully: %s", image_id)
+
+        # Start the container
+        try:
+            # TODO: Work out why this cast is necessary.
+            self._container = cast(
+                docker.models.containers.Container,
+                await asyncio.to_thread(
+                    self._client.containers.run,
+                    image=self.image,
+                    name=self.name,
+                    # Ensure the container stays running.
+                    command="tail -f /dev/null",
+                    detach=True,
+                    environment=env,
+                ),
+            )
+        except docker.errors.ImageNotFound as e:
+            raise DockerBuildError(
+                f"Docker image not found: {self.image}\nEnsure the image exists or provide a Dockerfile path."
+            ) from e
+        except docker.errors.APIError as e:
+            raise DockerBuildError(f"Docker API error while starting container: {e}") from e
 
     async def stop(self) -> None:
         """Stop the container."""


### PR DESCRIPTION
## Summary

This PR fixes the "email must be verified before using account" Docker Hub authentication error by adding support for anonymous pulls and improving error handling.

**Key Changes:**
- Add `DOCKER_SKIP_AUTH` config option to use anonymous pulls without a Docker Hub account
- Implement automatic credential clearing from `~/.docker/config.json` when anonymous mode is enabled
- Add Docker image caching to avoid rebuilding the same Dockerfile repeatedly across resets
- Improve error detection and messages with specific guidance for "email must be verified" errors
- Support programmatic authentication via `DOCKER_REGISTRY_USERNAME`/`PASSWORD` environment variables

## Test Plan

- All 67 existing tests pass without modification
- Linting and formatting verified with ruff
- Type checking confirmed with pyright
- Changes are backwards compatible - existing authentication methods still work

## Usage

Users encountering Docker auth errors can now simply set:
```bash
DOCKER_SKIP_AUTH=true uv run -m examples.01_sequential_eval_with_local_llm
```

No Docker Hub account or email verification required.