### PR TITLE
Fix evaluation workers hanging due to missing exec_run() timeouts

### DIFF
--- a/src/ares/code_agents/mini_swe_agent.py
+++ b/src/ares/code_agents/mini_swe_agent.py
@@ -159,10 +159,13 @@ class MiniSWECodeAgent(code_agent_base.CodeAgent):
         with self.tracker.timeit("mswea/setup"):
             _LOGGER.debug("[%d] Starting mini-swe-agent run.", id(self))
 
-            system = (await self.container.exec_run("uname -a", env=self._environment_env_vars)).output.strip()
-            release = (await self.container.exec_run("uname -r", env=self._environment_env_vars)).output.strip()
-            version = (await self.container.exec_run("uname -v", env=self._environment_env_vars)).output.strip()
-            machine = (await self.container.exec_run("uname -m", env=self._environment_env_vars)).output.strip()
+            # Use a short timeout for system info commands - these should complete quickly.
+            setup_timeout_s = 30
+            env = self._environment_env_vars
+            system = (await self.container.exec_run("uname -a", timeout_s=setup_timeout_s, env=env)).output.strip()
+            release = (await self.container.exec_run("uname -r", timeout_s=setup_timeout_s, env=env)).output.strip()
+            version = (await self.container.exec_run("uname -v", timeout_s=setup_timeout_s, env=env)).output.strip()
+            machine = (await self.container.exec_run("uname -m", timeout_s=setup_timeout_s, env=env)).output.strip()
 
             _LOGGER.debug("[%d] System information: %s %s %s %s", id(self), system, release, version, machine)
 


### PR DESCRIPTION
# User description
## Problem

Evaluation workers hang indefinitely when running example 3 (`03_parallel_eval_with_api.py`). Symptom: 18 agent steps observed but wall-clock time far exceeding the expected 18 × 2 min = 36 min. Reported by Josh.

## Root Cause

Four `exec_run()` call sites were missing `timeout_s`, so a single unresponsive container exec could block the entire evaluation indefinitely — even though per-operation timeouts appear to exist elsewhere.

### 1. `mini_swe_agent.py` — agent setup has no timeout
The 4 `uname` commands run with no `timeout_s`. If Daytona is slow during container startup, the `code_agent_task` hangs **before making any LLM request**, blocking `_get_time_step()` forever via `asyncio.wait()`.

### 2. `code_env.py` (`_compute_reward`) — test execution has no timeout
`bash {test_path}` and reward file `cat` calls use no timeout. If a test script contains an infinite loop or the container hangs during scoring, the episode hangs indefinitely after the agent finishes all its steps.

### 3. `code_env.py` (`_get_time_step`) — `asyncio.wait()` has no timeout
No backstop at the step level. Even when per-operation timeouts are set, if the underlying Daytona SDK delays propagating `CancelledError` (e.g. during server-side cancel cleanup), the effective timeout can far exceed the configured value.

### 4. `examples/03_parallel_eval_with_api.py` — no per-task wall-clock limit
A hung task holds a semaphore slot indefinitely, reducing effective parallelism from `num_parallel_workers` down as workers pile up.

## Fix

| File | Change |
|------|--------|
| `mini_swe_agent.py` | Add `timeout_s=30` to the 4 setup `exec_run()` calls |
| `code_env.py` | Add `_REWARD_EXEC_TIMEOUT_S = 300` (5 min) to all exec calls in `_compute_reward()` and `_parse_reward_file()` |
| `code_env.py` | Add `timeout=_GET_TIME_STEP_TIMEOUT_S` (10 min) to `asyncio.wait()` in `_get_time_step()` with a clear `TimeoutError` |
| `examples/03_parallel_eval_with_api.py` | Wrap each `evaluate_task()` with `asyncio.wait_for(timeout=args.task_timeout_s)` (default 30 min); timed-out tasks surface as errors via `gather(return_exceptions=True)` |

## Testing

All 163 existing tests pass. End-to-end testing with Daytona in progress.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implements comprehensive timeouts across container execution calls and task management to prevent evaluation workers from hanging indefinitely. These changes ensure that unresponsive container operations or delayed cancellations do not block system resources or parallel execution slots.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/93?tool=ast&topic=Execution+Timeouts>Execution Timeouts</a>
        </td><td>Integrates <code>timeout_s</code> into <code>exec_run</code> calls within <code>MiniSWECodeAgent</code> and <code>CodeEnvironment</code> to prevent blocking during agent setup, test execution, and reward parsing.<details><summary>Modified files (2)</summary><ul><li>src/ares/code_agents/mini_swe_agent.py</li>
<li>src/ares/environments/code_env.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>joshua.greaves@gmail.com</td><td>Add-an-LLMResponse-mod...</td><td>January 29, 2026</td></tr>
<tr><td>ryan@withmartian.com</td><td>Allowed-all-harbor-dat...</td><td>January 28, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/93?tool=ast&topic=Task+Safeguards>Task Safeguards</a>
        </td><td>Adds a 10-minute backstop to <code>_get_time_step</code> using <code>asyncio.wait</code> and introduces a configurable <code>task_timeout_s</code> in the parallel evaluation script to safeguard against hung tasks.<details><summary>Modified files (2)</summary><ul><li>examples/03_parallel_eval_with_api.py</li>
<li>src/ares/environments/code_env.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ryan@withmartian.com</td><td>Fail-fast-cleanups-76</td><td>January 29, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Fail-fast-if-required-...</td><td>January 29, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/withmartian/ares/93?tool=ast>(Baz)</a>.