### PR TITLE
Add agent state serialization for Go-Explore checkpointing

### DIFF
--- a/src/ares/code_agents/code_agent_base.py
+++ b/src/ares/code_agents/code_agent_base.py
@@ -1,5 +1,6 @@
 """An interface for code agents."""
 
+import dataclasses
 from typing import Protocol
 
 from ares.containers import containers
@@ -15,6 +16,49 @@ class CodeAgent(Protocol):
 
 class CodeAgentFactory[T: CodeAgent](Protocol):
     def __call__(self, *, container: containers.Container, llm_client: llm_clients.LLMClient) -> T: ...
+
+
+@dataclasses.dataclass(frozen=True)
+class CodeAgentState:
+    """Serializable snapshot of a code agent's conversational state.
+
+    Captures everything needed to resume an agent from where it left off,
+    given that its container is in the correct filesystem state.
+    """
+
+    messages: list[request.Message]
+    n_calls: int
+    total_cost: float
+
+
+class CheckpointableCodeAgent(CodeAgent, Protocol):
+    """A CodeAgent that supports state capture and restoration.
+
+    Used by Go-Explore to checkpoint and resume agents at arbitrary
+    points in their execution.
+    """
+
+    def get_state(self) -> CodeAgentState:
+        """Capture the agent's current conversational state.
+
+        Returns:
+            A CodeAgentState that can be passed to restore_and_resume().
+        """
+        ...
+
+    async def restore_and_resume(self, state: CodeAgentState, task: str) -> None:
+        """Restore agent state and resume execution from the next LLM call.
+
+        Sets the agent's message history and counters to the saved state,
+        then enters the normal query/execute loop. The first query() call
+        will produce an LLM request with the restored message history,
+        which gets intercepted by the QueueMediatedLLMClient.
+
+        Args:
+            state: A previously captured CodeAgentState.
+            task: The task instruction (used for context, not re-executed).
+        """
+        ...
 
 
 class TrivialCodeAgent(CodeAgent):

--- a/src/ares/code_agents/mini_swe_agent.py
+++ b/src/ares/code_agents/mini_swe_agent.py
@@ -11,6 +11,7 @@ GH link: https://github.com/SWE-agent/mini-swe-agent
 Commit hash: 6ff7d26ac371e5bb9611ec37074fc1bedf400895
 """
 
+import copy
 import dataclasses
 import logging
 import os
@@ -117,7 +118,7 @@ class MiniSWECodeAgent(code_agent_base.CodeAgent):
     tracker: stat_tracker.StatTracker = dataclasses.field(default_factory=stat_tracker.NullStatTracker)
 
     def __post_init__(self):
-        config_path = pathlib.Path(minisweagent.config.builtin_config_dir) / "extra" / "swebench.yaml"
+        config_path = pathlib.Path(minisweagent.config.builtin_config_dir) / "benchmarks" / "swebench.yaml"
         self._config = yaml.safe_load(config_path.read_text())
         self._agent_config = self._config.get("agent", {})
 
@@ -126,14 +127,13 @@ class MiniSWECodeAgent(code_agent_base.CodeAgent):
         self._environment_env_vars = environment_config.get("env", None)
 
         # Somewhat frustratingly, minisweagent uses kwargs.
-        # We handle this by inspecting whether an argument will be accepted by the agent config.
+        # We handle this by filtering to only fields that AgentConfig accepts.
         agent_config_dict = self._config.get("agent", {})
-        agent_config = default_agent.AgentConfig()
-        for k, v in agent_config_dict.items():
-            if hasattr(default_agent.AgentConfig, k):
-                setattr(agent_config, k, v)
-            else:
-                _LOGGER.info("Ignoring argument %s in agent configuration.", k)
+        accepted_fields = set(default_agent.AgentConfig.model_fields)
+        filtered_config = {k: v for k, v in agent_config_dict.items() if k in accepted_fields}
+        for k in set(agent_config_dict) - set(filtered_config):
+            _LOGGER.info("Ignoring argument %s in agent configuration.", k)
+        agent_config = default_agent.AgentConfig(**filtered_config)  # noqa: F841
 
         # Initialize step and cost tracking
         self._n_calls = 0
@@ -144,6 +144,39 @@ class MiniSWECodeAgent(code_agent_base.CodeAgent):
         self._system_prompt = _render_system_template(self._agent_config["system_template"])
         self._messages: list[request.Message] = []
         _LOGGER.debug("[%d] Initialized MiniSWECodeAgent.", id(self))
+
+    def get_state(self) -> code_agent_base.CodeAgentState:
+        """Capture the agent's current conversational state."""
+        return code_agent_base.CodeAgentState(
+            messages=copy.deepcopy(self._messages),
+            n_calls=self._n_calls,
+            total_cost=self._total_cost,
+        )
+
+    async def restore_and_resume(self, state: code_agent_base.CodeAgentState, task: str) -> None:
+        """Restore state and resume the agent loop from the next LLM call.
+
+        This is the tail of run() without the setup preamble. The agent
+        picks up from its saved message history and resumes the
+        query/execute loop.
+        """
+        del task  # The task context is already in the saved messages.
+
+        self._messages = copy.deepcopy(state.messages)
+        self._n_calls = state.n_calls
+        self._total_cost = state.total_cost
+
+        while True:
+            try:
+                with self.tracker.timeit("mswea/step"):
+                    await self.step()
+            except _NonTerminatingError as e:
+                _LOGGER.debug("[%d] Non-terminating error: %s", id(self), e)
+                self._add_message("user", repr(e))
+            except _TerminatingError as e:
+                _LOGGER.debug("[%d] Terminating error: %s", id(self), e)
+                self._add_message("user", repr(e))
+                return
 
     def _add_message(self, role: Literal["user", "assistant"], content: str) -> None:
         if role == "user":

--- a/src/ares/code_agents/mini_swe_agent_state_test.py
+++ b/src/ares/code_agents/mini_swe_agent_state_test.py
@@ -1,0 +1,110 @@
+"""Tests for MiniSWECodeAgent state serialization."""
+
+import pytest
+
+from ares.code_agents import code_agent_base
+from ares.code_agents import mini_swe_agent
+from ares.containers import containers
+from ares.llms import request
+from ares.testing import mock_container
+from ares.testing import mock_llm
+
+
+def _make_agent() -> mini_swe_agent.MiniSWECodeAgent:
+    """Create a MiniSWECodeAgent with mock dependencies."""
+    container = mock_container.MockContainer()
+    llm_client = mock_llm.MockLLMClient()
+    return mini_swe_agent.MiniSWECodeAgent(container=container, llm_client=llm_client)
+
+
+def test_get_state_captures_empty_state():
+    """Test get_state() on a freshly created agent."""
+    agent = _make_agent()
+    state = agent.get_state()
+
+    assert state.messages == []
+    assert state.n_calls == 0
+    assert state.total_cost == 0.0
+
+
+def test_get_state_captures_messages():
+    """Test get_state() after messages have been added."""
+    agent = _make_agent()
+    agent._messages = [
+        request.UserMessage(role="user", content="hello"),
+        request.AssistantMessage(role="assistant", content="world"),
+    ]
+    agent._n_calls = 5
+    agent._total_cost = 1.23
+
+    state = agent.get_state()
+
+    assert len(state.messages) == 2
+    assert state.messages[0]["content"] == "hello"
+    assert state.messages[1]["content"] == "world"
+    assert state.n_calls == 5
+    assert state.total_cost == 1.23
+
+
+def test_get_state_returns_deep_copy():
+    """Test that get_state() returns independent copies of messages."""
+    agent = _make_agent()
+    agent._messages = [request.UserMessage(role="user", content="original")]
+
+    state = agent.get_state()
+
+    # Mutate the agent's messages
+    agent._messages.append(request.UserMessage(role="user", content="added"))
+
+    # State should not be affected
+    assert len(state.messages) == 1
+
+
+def test_code_agent_state_is_frozen():
+    """Test that CodeAgentState is immutable."""
+    state = code_agent_base.CodeAgentState(
+        messages=[],
+        n_calls=0,
+        total_cost=0.0,
+    )
+    with pytest.raises(AttributeError):
+        state.n_calls = 5  # type: ignore[misc]
+
+
+@pytest.mark.asyncio
+async def test_restore_and_resume_sets_state():
+    """Test that restore_and_resume restores messages and counters."""
+    agent = _make_agent()
+
+    saved_messages = [
+        request.UserMessage(role="user", content="saved message"),
+        request.AssistantMessage(role="assistant", content="saved response"),
+    ]
+    state = code_agent_base.CodeAgentState(
+        messages=saved_messages,
+        n_calls=3,
+        total_cost=0.5,
+    )
+
+    # Configure mock LLM to trigger submission so the loop terminates
+    agent.llm_client = mock_llm.MockLLMClient(
+        responses=["```bash\necho 'MINI_SWE_AGENT_FINAL_OUTPUT'\n```"],
+    )
+    # Configure container to return the submission output
+    agent.container = mock_container.MockContainer(
+        exec_responses={
+            "echo 'MINI_SWE_AGENT_FINAL_OUTPUT'": containers.ExecResult(
+                output="MINI_SWE_AGENT_FINAL_OUTPUT\n",
+                exit_code=0,
+            )
+        },
+    )
+
+    await agent.restore_and_resume(state, task="ignored")
+
+    # State should have been restored before the loop ran
+    assert agent._n_calls == 4  # 3 from state + 1 from the query in the loop
+    assert len(agent._messages) >= 2  # At least the restored messages
+    # The first two messages should be the restored ones
+    assert agent._messages[0]["content"] == "saved message"
+    assert agent._messages[1]["content"] == "saved response"

--- a/src/ares/presets.py
+++ b/src/ares/presets.py
@@ -125,14 +125,19 @@ def _register_default_presets() -> None:
     This function is called automatically when the presets module is imported,
     ensuring built-in presets are always available.
     """
+    seen: set[str] = set()
     for ds_spec in code_env.list_harbor_datasets():
         for code_agent_id, code_agent_factory in [
             ("mswea", mini_swe_agent.MiniSWECodeAgent),
             ("terminus2", terminus2_agent.Terminus2Agent),
         ]:
             ds_id = _make_harbor_dataset_id(ds_spec.name, ds_spec.version)
+            preset_name = f"{ds_id}-{code_agent_id}"
+            if preset_name in seen:
+                continue
+            seen.add(preset_name)
             registry.register_preset(
-                f"{ds_id}-{code_agent_id}",
+                preset_name,
                 HarborSpec(
                     ds_spec=ds_spec,
                     dataset_id=ds_id,


### PR DESCRIPTION
# User description
## Summary

- Adds `CodeAgentState` frozen dataclass capturing an agent's conversational state (messages, call count, cost)
- Adds `CheckpointableCodeAgent` protocol extending `CodeAgent` with `get_state()` and `restore_and_resume()`
- Implements both methods on `MiniSWECodeAgent` -- `restore_and_resume()` injects saved message history and re-enters the step loop without re-running the setup preamble
- Fixes pre-existing duplicate preset registration bug in `presets.py`

## Context

Part of Go-Explore support (Wave 1). This PR is independent of the other two Wave 1 PRs and can be reviewed/merged in parallel:
- PR: SnapshotableContainer protocol (`go-explore/snapshotable-container`)
- PR: EnvironmentCheckpoint protocol (`go-explore/checkpoint-protocol`)

The key insight: at any checkpoint, a code agent's behavior is fully determined by its message history. Given the same messages and a container in the correct filesystem state, the agent can resume from any point without replaying commands.

## Tests

5 new tests covering state capture, deep copy isolation, immutability, and restore+resume with mock LLM/container.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce <code>CodeAgentState</code> and <code>CheckpointableCodeAgent</code> to capture conversational context and enable <code>MiniSWECodeAgent</code> to serialize/deep-copy/restore its message/counter state for checkpointing in Go-Explore, complete with tests ensuring immutability and restore behavior. Fix default preset registration by deduplicating harbor dataset/code agent identifiers when populating the registry.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/95?tool=ast&topic=Agent+Checkpointing>Agent Checkpointing</a>
        </td><td>Enable checkpoint flow by adding <code>CodeAgentState</code>/<code>CheckpointableCodeAgent</code>, letting <code>MiniSWECodeAgent</code> capture, deep-copy, and resume its conversational state while exercising the new behavior via targeted agent tests.<details><summary>Modified files (3)</summary><ul><li>src/ares/code_agents/code_agent_base.py</li>
<li>src/ares/code_agents/mini_swe_agent.py</li>
<li>src/ares/code_agents/mini_swe_agent_state_test.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>joshua.greaves@gmail.com</td><td>Add-an-LLMResponse-mod...</td><td>January 29, 2026</td></tr>
<tr><td>ryan@withmartian.com</td><td>Allowed-all-harbor-dat...</td><td>January 28, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/95?tool=ast&topic=Preset+Dedup>Preset Dedup</a>
        </td><td>Prevent duplicate default presets by tracking seen harbor dataset/code agent combinations before registering them in the preset registry.<details><summary>Modified files (1)</summary><ul><li>src/ares/presets.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Narmeen07</td><td>Add-mechanistic-interp...</td><td>February 19, 2026</td></tr>
<tr><td>ryan@withmartian.com</td><td>Removed-repeated-indiv...</td><td>January 29, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/withmartian/ares/95?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent checkpointing: immutable conversational snapshots and restore-and-resume support; includes assistant-role messages and resumed run-loop handling.

* **Bug Fixes**
  * Prevented duplicate preset registrations during initialization.

* **Tests**
  * Added unit tests for state capture, immutability, deep-copy behavior, and restore-and-resume workflows.

* **Chores**
  * Updated benchmark config path and tightened agent configuration loading/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->