### PR TITLE
Add EnvironmentCheckpoint and CheckpointableEnvironment protocol

### DIFF
--- a/src/ares/__init__.py
+++ b/src/ares/__init__.py
@@ -45,7 +45,9 @@ All other functionality is available via submodules:
 # Import presets first to register defaults
 # This must come before we expose make and info to ensure presets are available
 from ares import presets  # noqa: F401
+from ares.environments.base import CheckpointableEnvironment
 from ares.environments.base import Environment
+from ares.environments.base import EnvironmentCheckpoint
 from ares.environments.base import TimeStep
 from ares.registry import EnvironmentInfo
 
@@ -58,7 +60,9 @@ from ares.registry import register_preset
 
 # Define public API
 __all__ = [
+    "CheckpointableEnvironment",
     "Environment",
+    "EnvironmentCheckpoint",
     "EnvironmentInfo",
     "TimeStep",
     "info",

--- a/src/ares/environments/base.py
+++ b/src/ares/environments/base.py
@@ -2,6 +2,8 @@
 dm_env Environment protocol and utilities for ARES.
 """
 
+import atexit
+from collections.abc import Awaitable, Callable
 import functools
 import logging
 import os
@@ -147,6 +149,150 @@ class Environment[ActionType, ObservationType, RewardType: Scalar, DiscountType:
         """Allows the environment to be used in an async with-statement context."""
         del exc_type, exc_value, traceback  # Unused.
         await self.close()
+
+
+class EnvironmentCheckpoint[EnvType]:
+    """A restorable snapshot of environment state at a step boundary.
+
+    Generic over the environment type so that restore() returns the concrete type.
+    The checkpoint is self-contained: it holds closures for restore and release
+    that capture whatever data and factories are needed. The environment that
+    creates it decides how those closures work.
+
+    restore() creates a brand new environment instance in the checkpointed state.
+    The original environment is not affected. Multiple restores from the same
+    checkpoint create independent environments.
+
+    Usage::
+
+        checkpoint = await env.checkpoint()
+        env_restored, ts = await checkpoint.restore()
+        # env_restored is a new, independent environment at the checkpointed state
+
+    Resource management:
+        Each checkpoint may hold expensive resources (e.g., a Docker image from
+        ``docker commit``). Call release() when no longer needed, or rely on the
+        global checkpoint janitor for atexit cleanup.
+    """
+
+    def __init__(
+        self,
+        *,
+        restore_fn: Callable[[], Awaitable[EnvType]],
+        release_fn: Callable[[], Awaitable[None]] | None = None,
+        release_fn_sync: Callable[[], None] | None = None,
+        step_count: int,
+        timestep: TimeStep,
+    ):
+        self._restore_fn = restore_fn
+        self._release_fn = release_fn
+        self._release_fn_sync = release_fn_sync
+        self.step_count = step_count
+        self.timestep = timestep
+        self._released = False
+
+        _CHECKPOINT_JANITOR.register(self)
+
+    async def restore(self) -> tuple[EnvType, TimeStep]:
+        """Create a new environment at this checkpoint's state.
+
+        Constructs a brand new environment instance initialised to the
+        checkpointed state. The original environment is not touched.
+        The caller owns the returned environment and must close() it.
+
+        Can be called multiple times -- each call creates an independent
+        environment.
+
+        Returns:
+            A tuple of (environment, timestep) where the environment is a new
+            instance and the timestep is the observation at the checkpointed state.
+        """
+        if self._released:
+            raise RuntimeError("Cannot restore from a released checkpoint.")
+        env = await self._restore_fn()
+        return env, self.timestep
+
+    async def release(self) -> None:
+        """Release resources held by this checkpoint.
+
+        For environments backed by containers, this deletes the snapshot image.
+        For simple environments, this is a no-op. Safe to call multiple times.
+        After release(), restore() will raise RuntimeError.
+        """
+        if self._released:
+            return
+        self._released = True
+        if self._release_fn is not None:
+            await self._release_fn()
+        _CHECKPOINT_JANITOR.unregister(self)
+
+    @property
+    def is_released(self) -> bool:
+        """Whether this checkpoint's resources have been released."""
+        return self._released
+
+
+class CheckpointableEnvironment[ActionType, ObservationType, RewardType: Scalar, DiscountType: Scalar](
+    Environment[ActionType, ObservationType, RewardType, DiscountType],
+    Protocol,
+):
+    """An Environment that supports checkpointing for exploration algorithms.
+
+    Extends the base Environment protocol with a single method: checkpoint().
+    Everything else (restore, release, cleanup) lives on the returned
+    EnvironmentCheckpoint object.
+
+    The implementation constructs the checkpoint with closures that know how
+    to create a brand new environment at the checkpointed state. No internal
+    protocol methods are imposed -- the implementation is free.
+    """
+
+    async def checkpoint(self) -> EnvironmentCheckpoint[Self]:
+        """Capture the current environment state.
+
+        Must be called at a step boundary (after reset() or step() returned
+        a non-LAST timestep, before the next step() call).
+
+        Returns:
+            An EnvironmentCheckpoint whose restore() creates a new instance
+            of this concrete environment type.
+        """
+        ...
+
+
+class _CheckpointJanitor:
+    """Emergency cleanup for checkpoints that weren't explicitly released.
+
+    Mirrors the _Janitor pattern in code_env.py for container cleanup.
+    Registered checkpoints are cleaned up synchronously at interpreter exit.
+    """
+
+    def __init__(self):
+        self._checkpoints: dict[int, EnvironmentCheckpoint] = {}
+        atexit.register(self._cleanup)
+
+    def register(self, checkpoint: EnvironmentCheckpoint) -> None:
+        """Register a checkpoint for emergency cleanup."""
+        self._checkpoints[id(checkpoint)] = checkpoint
+
+    def unregister(self, checkpoint: EnvironmentCheckpoint) -> None:
+        """Unregister a checkpoint from emergency cleanup."""
+        self._checkpoints.pop(id(checkpoint), None)
+
+    def _cleanup(self) -> None:
+        """Clean up all registered checkpoints at exit."""
+        if self._checkpoints:
+            _LOGGER.info("Cleaning up %d unreleased checkpoints at exit.", len(self._checkpoints))
+        for cp in list(self._checkpoints.values()):
+            if cp._release_fn_sync is not None:
+                try:
+                    cp._release_fn_sync()
+                except Exception:
+                    _LOGGER.warning("Failed to clean up checkpoint.", exc_info=True)
+        self._checkpoints.clear()
+
+
+_CHECKPOINT_JANITOR = _CheckpointJanitor()
 
 
 async def create_container(

--- a/src/ares/environments/checkpoint_test.py
+++ b/src/ares/environments/checkpoint_test.py
@@ -1,0 +1,234 @@
+"""Tests for EnvironmentCheckpoint and CheckpointableEnvironment."""
+
+import pytest
+
+from ares.environments import base
+
+
+@pytest.fixture
+def simple_timestep() -> base.TimeStep:
+    """Create a simple TimeStep for testing."""
+    return base.TimeStep(step_type="MID", reward=0.0, discount=1.0, observation="test_obs")
+
+
+class TestEnvironmentCheckpoint:
+    """Tests for EnvironmentCheckpoint."""
+
+    @pytest.mark.asyncio
+    async def test_restore_returns_env_and_timestep(self, simple_timestep):
+        """Test that restore() returns the env from restore_fn and the stored timestep."""
+        mock_env = object()
+
+        async def restore_fn():
+            return mock_env
+
+        checkpoint = base.EnvironmentCheckpoint(
+            restore_fn=restore_fn,
+            step_count=5,
+            timestep=simple_timestep,
+        )
+
+        env, ts = await checkpoint.restore()
+        assert env is mock_env
+        assert ts is simple_timestep
+
+    @pytest.mark.asyncio
+    async def test_restore_creates_independent_envs(self, simple_timestep):
+        """Test that multiple restores create independent environments."""
+        call_count = 0
+
+        async def restore_fn():
+            nonlocal call_count
+            call_count += 1
+            return {"id": call_count}
+
+        checkpoint = base.EnvironmentCheckpoint(
+            restore_fn=restore_fn,
+            step_count=0,
+            timestep=simple_timestep,
+        )
+
+        env_a, _ = await checkpoint.restore()
+        env_b, _ = await checkpoint.restore()
+        assert env_a != env_b
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_release_calls_release_fn(self, simple_timestep):
+        """Test that release() calls the release function."""
+        released = False
+
+        async def release_fn():
+            nonlocal released
+            released = True
+
+        async def restore_fn():
+            return object()
+
+        checkpoint = base.EnvironmentCheckpoint(
+            restore_fn=restore_fn,
+            release_fn=release_fn,
+            step_count=0,
+            timestep=simple_timestep,
+        )
+
+        await checkpoint.release()
+        assert released
+        assert checkpoint.is_released
+
+    @pytest.mark.asyncio
+    async def test_release_is_idempotent(self, simple_timestep):
+        """Test that release() can be called multiple times safely."""
+        call_count = 0
+
+        async def release_fn():
+            nonlocal call_count
+            call_count += 1
+
+        async def restore_fn():
+            return object()
+
+        checkpoint = base.EnvironmentCheckpoint(
+            restore_fn=restore_fn,
+            release_fn=release_fn,
+            step_count=0,
+            timestep=simple_timestep,
+        )
+
+        await checkpoint.release()
+        await checkpoint.release()
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_restore_after_release_raises(self, simple_timestep):
+        """Test that restore() raises after release()."""
+
+        async def restore_fn():
+            return object()
+
+        checkpoint = base.EnvironmentCheckpoint(
+            restore_fn=restore_fn,
+            step_count=0,
+            timestep=simple_timestep,
+        )
+
+        await checkpoint.release()
+        with pytest.raises(RuntimeError, match="released"):
+            await checkpoint.restore()
+
+    @pytest.mark.asyncio
+    async def test_no_release_fn_is_ok(self, simple_timestep):
+        """Test that checkpoints without release_fn work fine."""
+
+        async def restore_fn():
+            return object()
+
+        checkpoint = base.EnvironmentCheckpoint(
+            restore_fn=restore_fn,
+            step_count=0,
+            timestep=simple_timestep,
+        )
+
+        # Release should be a no-op
+        await checkpoint.release()
+        assert checkpoint.is_released
+
+    def test_step_count_accessible(self, simple_timestep):
+        """Test that step_count is publicly accessible."""
+
+        async def restore_fn():
+            return object()
+
+        checkpoint = base.EnvironmentCheckpoint(
+            restore_fn=restore_fn,
+            step_count=42,
+            timestep=simple_timestep,
+        )
+
+        assert checkpoint.step_count == 42
+
+    def test_timestep_accessible(self, simple_timestep):
+        """Test that timestep is publicly accessible."""
+
+        async def restore_fn():
+            return object()
+
+        checkpoint = base.EnvironmentCheckpoint(
+            restore_fn=restore_fn,
+            step_count=0,
+            timestep=simple_timestep,
+        )
+
+        assert checkpoint.timestep is simple_timestep
+
+
+class TestCheckpointJanitor:
+    """Tests for _CheckpointJanitor."""
+
+    def test_register_and_unregister(self, simple_timestep):
+        """Test that register/unregister tracks checkpoints."""
+        janitor = base._CheckpointJanitor()
+
+        async def restore_fn():
+            return object()
+
+        checkpoint = base.EnvironmentCheckpoint(
+            restore_fn=restore_fn,
+            step_count=0,
+            timestep=simple_timestep,
+        )
+
+        # Checkpoint auto-registers with the global janitor, but
+        # we test the local janitor instance here.
+        janitor.register(checkpoint)
+        assert id(checkpoint) in janitor._checkpoints
+
+        janitor.unregister(checkpoint)
+        assert id(checkpoint) not in janitor._checkpoints
+
+    def test_cleanup_calls_sync_release(self, simple_timestep):
+        """Test that janitor cleanup calls release_fn_sync."""
+        janitor = base._CheckpointJanitor()
+        released = False
+
+        def release_sync():
+            nonlocal released
+            released = True
+
+        async def restore_fn():
+            return object()
+
+        checkpoint = base.EnvironmentCheckpoint(
+            restore_fn=restore_fn,
+            release_fn_sync=release_sync,
+            step_count=0,
+            timestep=simple_timestep,
+        )
+
+        janitor.register(checkpoint)
+        janitor._cleanup()
+
+        assert released
+        assert len(janitor._checkpoints) == 0
+
+    def test_cleanup_handles_exceptions(self, simple_timestep):
+        """Test that janitor cleanup handles exceptions gracefully."""
+        janitor = base._CheckpointJanitor()
+
+        def release_sync():
+            raise RuntimeError("cleanup failed")
+
+        async def restore_fn():
+            return object()
+
+        checkpoint = base.EnvironmentCheckpoint(
+            restore_fn=restore_fn,
+            release_fn_sync=release_sync,
+            step_count=0,
+            timestep=simple_timestep,
+        )
+
+        janitor.register(checkpoint)
+        # Should not raise
+        janitor._cleanup()
+        assert len(janitor._checkpoints) == 0

--- a/src/ares/presets.py
+++ b/src/ares/presets.py
@@ -125,12 +125,17 @@ def _register_default_presets() -> None:
     This function is called automatically when the presets module is imported,
     ensuring built-in presets are always available.
     """
+    seen_dataset_ids: set[str] = set()
     for ds_spec in code_env.list_harbor_datasets():
+        ds_id = _make_harbor_dataset_id(ds_spec.name, ds_spec.version)
+        if ds_id in seen_dataset_ids:
+            _LOGGER.debug("Skipping duplicate dataset '%s'", ds_id)
+            continue
+        seen_dataset_ids.add(ds_id)
         for code_agent_id, code_agent_factory in [
             ("mswea", mini_swe_agent.MiniSWECodeAgent),
             ("terminus2", terminus2_agent.Terminus2Agent),
         ]:
-            ds_id = _make_harbor_dataset_id(ds_spec.name, ds_spec.version)
             registry.register_preset(
                 f"{ds_id}-{code_agent_id}",
                 HarborSpec(


### PR DESCRIPTION
# User description
## Summary

- Adds `EnvironmentCheckpoint[EnvType]` -- a generic checkpoint object that holds closures for restore and release. `restore()` creates a brand new, independent environment instance at the checkpointed state.
- Adds `CheckpointableEnvironment` protocol extending `Environment` with a single `checkpoint()` method returning `EnvironmentCheckpoint[Self]`
- Adds `_CheckpointJanitor` for atexit cleanup of unreleased checkpoints (mirrors the existing `_Janitor` pattern in `code_env.py`)
- Exports `CheckpointableEnvironment` and `EnvironmentCheckpoint` from the top-level `ares` package
- Fixes pre-existing duplicate preset registration bug in `presets.py`

## Design

The environment protocol gains **one method**: `checkpoint()`. Everything else lives on the checkpoint object:

```python
checkpoint = await env.checkpoint()       # capture state
env, ts = await checkpoint.restore()      # create new env at that state
await checkpoint.release()                # free resources (Docker images, etc.)
```

The checkpoint takes closures from the environment -- no internal protocol methods are imposed. The environment is free to implement restore/release however it wants. See `local/analyses/go-explore/04-go-explore-sketch.py` for the full design rationale.

## Context

Part of Go-Explore support (Wave 1). This PR is independent of the other two Wave 1 PRs and can be reviewed/merged in parallel:
- PR: SnapshotableContainer protocol (`go-explore/snapshotable-container`)
- PR: Agent state serialization (`go-explore/agent-state-serialization`)

## Tests

11 new tests covering restore, independent env creation, release idempotency, restore-after-release errors, and janitor register/unregister/cleanup/exception handling.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce <code>EnvironmentCheckpoint</code> to capture restorable snapshots and extend <code>CheckpointableEnvironment</code> so environments can expose checkpoint/restore/release flows along with a <code>_CheckpointJanitor</code> for cleanup; export these new APIs at the package level. Add focused tests covering restore, release, idempotency, and janitor cleanup to ensure the new checkpoint semantics work and register with the existing infrastructure.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/96?tool=ast&topic=Checkpoint+Flow>Checkpoint Flow</a>
        </td><td>Describe how <code>EnvironmentCheckpoint</code>, <code>CheckpointableEnvironment</code>, and <code>_CheckpointJanitor</code> capture state, restore new environments, release resources, and are covered by new async tests for checkpoint behavior and cleanup.<details><summary>Modified files (3)</summary><ul><li>src/ares/__init__.py</li>
<li>src/ares/environments/base.py</li>
<li>src/ares/environments/checkpoint_test.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Narmeen07</td><td>Add-mechanistic-interp...</td><td>February 19, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Massively-simplify-the...</td><td>January 29, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/96?tool=ast&topic=Preset+Dedup>Preset Dedup</a>
        </td><td>Prevent duplicate Harbor dataset presets by tracking seen IDs before registering each combination of dataset and agent.<details><summary>Modified files (1)</summary><ul><li>src/ares/presets.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Narmeen07</td><td>Add-mechanistic-interp...</td><td>February 19, 2026</td></tr>
<tr><td>ryan@withmartian.com</td><td>Removed-repeated-indiv...</td><td>January 29, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/withmartian/ares/96?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment checkpointing: snapshot and restore independent environment copies, explicit release/is-released semantics, and automatic cleanup of unreleased checkpoints at program exit; checkpointing types now accessible from the package root.

* **Chores**
  * Deduplicated dataset registrations during preset initialization to avoid repeated registrations.

* **Tests**
  * Added tests covering checkpoint restore/release semantics and janitor cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->