### PR TITLE
Fix TypeError and docstrings in Container.upload_dir

### DIFF
--- a/src/ares/containers/containers.py
+++ b/src/ares/containers/containers.py
@@ -62,11 +62,11 @@ class Container(Protocol):
 
     @abc.abstractmethod
     async def upload_files(self, local_paths: list[pathlib.Path], remote_paths: list[str]) -> None:
-        """Upload a file to the container.
+        """Upload files to the container.
 
         Args:
-            local_path: The path to the local file.
-            remote_path: The path to the remote file.
+            local_paths: The paths to the local files.
+            remote_paths: The paths to the remote files.
         """
 
     @abc.abstractmethod
@@ -74,8 +74,8 @@ class Container(Protocol):
         """Download files from the container.
 
         Args:
-            remote_paths: The path to the remote files.
-            local_paths: The path to the local files.
+            remote_paths: The paths to the remote files.
+            local_paths: The paths to the local files.
         """
 
     async def upload_file(self, local_path: pathlib.Path, remote_path: str) -> None:
@@ -90,9 +90,9 @@ class Container(Protocol):
         for file_path in local_path.rglob("*"):
             if file_path.is_file():
                 relative_path = file_path.relative_to(local_path)
-                destination_path = str(remote_path / relative_path)
+                destination_path = str(pathlib.Path(remote_path) / relative_path)
 
-                local_path_uploads.append(str(file_path))
+                local_path_uploads.append(file_path)
                 remote_path_uploads.append(destination_path)
 
         await self.upload_files(local_path_uploads, remote_path_uploads)


### PR DESCRIPTION
## Summary

Fixes two runtime bugs and two docstring issues in `src/ares/containers/containers.py`:

### Bug fixes
- **`upload_dir`: `TypeError` on path join** — `remote_path` is a `str`, but the code used `remote_path / relative_path` (the `/` operator), which only works on `pathlib.Path`. Wrapped with `pathlib.Path(remote_path)` to fix.
- **`upload_dir`: wrong type passed to `upload_files`** — `local_path_uploads` was appending `str(file_path)` but `upload_files` expects `list[pathlib.Path]`. Removed the erroneous `str()` cast.

### Docstring fixes
- **`upload_files`**: "Upload a file" → "Upload files"; `local_path`/`remote_path` → `local_paths`/`remote_paths`
- **`download_files`**: "The path" → "The paths" for both args

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced consistency and reliability in path handling for file upload and download operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->