### PR TITLE
Version duplicate Harbor preset IDs

### DIFF
--- a/src/ares/presets.py
+++ b/src/ares/presets.py
@@ -8,7 +8,7 @@ Do not add the registry mechanism itself to this module - that belongs in regist
 This module only contains preset registrations to avoid circular imports.
 """
 
-from collections import Counter
+import collections
 import dataclasses
 import functools
 import logging
@@ -127,7 +127,7 @@ def _register_default_presets() -> None:
     ensuring built-in presets are always available.
     """
     ds_specs = code_env.list_harbor_datasets()
-    dataset_name_counts = Counter(ds_spec.name for ds_spec in ds_specs)
+    dataset_name_counts = collections.Counter(ds_spec.name for ds_spec in ds_specs)
 
     for ds_spec in ds_specs:
         ds_id = _make_harbor_dataset_id(

--- a/src/ares/presets.py
+++ b/src/ares/presets.py
@@ -29,12 +29,13 @@ from ares.experiment_tracking import stat_tracker
 _LOGGER = logging.getLogger(__name__)
 
 
-def _make_harbor_dataset_id(name: str, version: str, *, include_version: bool = False) -> str:
+def _make_harbor_dataset_id(name: str, version: str | None = None) -> str:
     """Make a shorter Harbor dataset ID for ARES presets."""
-    if include_version or name == "swe-lancer-diamond":
-        name = f"{name}-{version}"
+    dataset_id = name.replace("swebench-verified", "sbv").replace("terminal-bench", "tbench")
+    if version is None:
+        return dataset_id
 
-    return name.replace("swebench-verified", "sbv").replace("terminal-bench", "tbench")
+    return f"{dataset_id}-{version}"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -127,14 +128,11 @@ def _register_default_presets() -> None:
     ensuring built-in presets are always available.
     """
     ds_specs = code_env.list_harbor_datasets()
-    dataset_name_counts = collections.Counter(ds_spec.name for ds_spec in ds_specs)
+    alias_id_counts = collections.Counter(_make_harbor_dataset_id(ds_spec.name) for ds_spec in ds_specs)
 
     for ds_spec in ds_specs:
-        ds_id = _make_harbor_dataset_id(
-            ds_spec.name,
-            ds_spec.version,
-            include_version=dataset_name_counts[ds_spec.name] > 1,
-        )
+        ds_id = _make_harbor_dataset_id(ds_spec.name, ds_spec.version)
+        alias_ds_id = _make_harbor_dataset_id(ds_spec.name)
 
         for code_agent_id, code_agent_factory in [
             ("mswea", mini_swe_agent.MiniSWECodeAgent),
@@ -149,6 +147,16 @@ def _register_default_presets() -> None:
                     code_agent_id=code_agent_id,
                 ),
             )
+            if alias_id_counts[alias_ds_id] == 1:
+                registry.register_preset(
+                    f"{alias_ds_id}-{code_agent_id}",
+                    HarborSpec(
+                        ds_spec=ds_spec,
+                        dataset_id=alias_ds_id,
+                        code_agent_factory=code_agent_factory,
+                        code_agent_id=code_agent_id,
+                    ),
+                )
 
     # Twenty Questions — lightweight, no Docker needed.
     registry.register_preset("20q", TwentyQuestionsSpec())

--- a/src/ares/presets.py
+++ b/src/ares/presets.py
@@ -8,6 +8,7 @@ Do not add the registry mechanism itself to this module - that belongs in regist
 This module only contains preset registrations to avoid circular imports.
 """
 
+from collections import Counter
 import dataclasses
 import functools
 import logging
@@ -28,10 +29,10 @@ from ares.experiment_tracking import stat_tracker
 _LOGGER = logging.getLogger(__name__)
 
 
-def _make_harbor_dataset_id(name: str, version: str) -> str:
-    """Small helper to make a shorter Dataset ID from the Harbor name and version"""
-    if name == "swe-lancer-diamond":
-        name = f"swe-lancer-diamond-{version}"
+def _make_harbor_dataset_id(name: str, version: str, *, include_version: bool = False) -> str:
+    """Make a shorter Harbor dataset ID for ARES presets."""
+    if include_version or name == "swe-lancer-diamond":
+        name = f"{name}-{version}"
 
     return name.replace("swebench-verified", "sbv").replace("terminal-bench", "tbench")
 
@@ -125,12 +126,20 @@ def _register_default_presets() -> None:
     This function is called automatically when the presets module is imported,
     ensuring built-in presets are always available.
     """
-    for ds_spec in code_env.list_harbor_datasets():
+    ds_specs = code_env.list_harbor_datasets()
+    dataset_name_counts = Counter(ds_spec.name for ds_spec in ds_specs)
+
+    for ds_spec in ds_specs:
+        ds_id = _make_harbor_dataset_id(
+            ds_spec.name,
+            ds_spec.version,
+            include_version=dataset_name_counts[ds_spec.name] > 1,
+        )
+
         for code_agent_id, code_agent_factory in [
             ("mswea", mini_swe_agent.MiniSWECodeAgent),
             ("terminus2", terminus2_agent.Terminus2Agent),
         ]:
-            ds_id = _make_harbor_dataset_id(ds_spec.name, ds_spec.version)
             registry.register_preset(
                 f"{ds_id}-{code_agent_id}",
                 HarborSpec(

--- a/src/ares/registry.py
+++ b/src/ares/registry.py
@@ -24,8 +24,8 @@ from ares.experiment_tracking import stat_tracker
 
 _LOGGER = logging.getLogger(__name__)
 
-# Valid preset name pattern: alphanumeric + hyphens, underscores, and forward slashes
-_PRESET_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_/-]+$")
+# Valid preset name pattern: alphanumeric + periods, hyphens, underscores, and forward slashes
+_PRESET_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_./-]+$")
 
 
 class TaskSelector(Protocol):
@@ -292,7 +292,7 @@ def register_preset(
     Args:
         name: Unique identifier for the preset. Convention is "dataset-variant" (e.g.,
             "swebench-lite", "harbor-easy"). Must not already exist in the registry.
-            Must contain only alphanumeric characters, hyphens, underscores, and forward slashes.
+            Must contain only alphanumeric characters, periods, hyphens, underscores, and forward slashes.
             Cannot contain colons or @ symbols as they are reserved for task selection syntax.
         spec: An EnvironmentSpec instance that provides both metadata (via get_info())
             and environment creation (via get_env()). The spec's get_env() method will
@@ -305,7 +305,8 @@ def register_preset(
     if not _PRESET_NAME_PATTERN.match(name):
         raise ValueError(
             f"Preset name '{name}' contains invalid characters. "
-            "Only alphanumeric characters, hyphens (-), underscores (_), and forward slashes (/) are allowed."
+            "Only alphanumeric characters, periods (.), hyphens (-), underscores (_), "
+            "and forward slashes (/) are allowed."
         )
 
     if name in _REGISTRY:

--- a/src/ares/registry_test.py
+++ b/src/ares/registry_test.py
@@ -81,8 +81,8 @@ def test_info_specific_preset():
     assert result.name == "sbv-mswea"
 
 
-def test_register_default_presets_versions_duplicate_harbor_dataset_names(monkeypatch):
-    """Test duplicate Harbor dataset names get versioned preset IDs."""
+def test_register_default_presets_versions_and_unambiguous_aliases(monkeypatch):
+    """Test Harbor presets get versioned IDs plus unambiguous unversioned aliases."""
     from ares import presets
 
     fake_ds_specs = (
@@ -106,6 +106,10 @@ def test_register_default_presets_versions_duplicate_harbor_dataset_names(monkey
         assert "kumo-parity-terminus2" in preset_names
         assert "kumo-1.0-terminus2" in preset_names
         assert "kumo-easy-terminus2" in preset_names
+        assert "sbv-latest-mswea" in preset_names
+        assert "tbench-latest-mswea" in preset_names
+        assert "kumo-mswea" not in preset_names
+        assert "kumo-terminus2" not in preset_names
         assert "sbv-mswea" in preset_names
         assert "tbench-mswea" in preset_names
         assert "20q" in preset_names

--- a/src/ares/registry_test.py
+++ b/src/ares/registry_test.py
@@ -49,6 +49,15 @@ class _MockEnvSpec:
         }
 
 
+@dataclasses.dataclass(frozen=True)
+class _FakeHarborDatasetSpec:
+    """Minimal fake for the Harbor DatasetSpec fields presets.py reads."""
+
+    name: str
+    version: str
+    tasks: tuple[object, ...] = ()
+
+
 def test_list_presets():
     """Test that default presets are registered."""
     presets = registry._list_presets()
@@ -70,6 +79,39 @@ def test_info_specific_preset():
     result = registry.info("sbv-mswea")
     assert isinstance(result, registry.EnvironmentInfo)
     assert result.name == "sbv-mswea"
+
+
+def test_register_default_presets_versions_duplicate_harbor_dataset_names(monkeypatch):
+    """Test duplicate Harbor dataset names get versioned preset IDs."""
+    from ares import presets
+
+    fake_ds_specs = (
+        _FakeHarborDatasetSpec(name="kumo", version="parity", tasks=(object(),)),
+        _FakeHarborDatasetSpec(name="kumo", version="1.0", tasks=(object(),)),
+        _FakeHarborDatasetSpec(name="kumo", version="easy", tasks=(object(),)),
+        _FakeHarborDatasetSpec(name="swebench-verified", version="latest", tasks=(object(),)),
+        _FakeHarborDatasetSpec(name="terminal-bench", version="latest", tasks=(object(),)),
+    )
+    original_registry = dict(registry._REGISTRY)
+    monkeypatch.setattr(presets.code_env, "list_harbor_datasets", lambda: fake_ds_specs)
+
+    registry.clear_registry()
+    try:
+        presets._register_default_presets()
+        preset_names = set(registry._list_presets())
+
+        assert "kumo-parity-mswea" in preset_names
+        assert "kumo-1.0-mswea" in preset_names
+        assert "kumo-easy-mswea" in preset_names
+        assert "kumo-parity-terminus2" in preset_names
+        assert "kumo-1.0-terminus2" in preset_names
+        assert "kumo-easy-terminus2" in preset_names
+        assert "sbv-mswea" in preset_names
+        assert "tbench-mswea" in preset_names
+        assert "20q" in preset_names
+    finally:
+        registry._REGISTRY.clear()
+        registry._REGISTRY.update(original_registry)
 
 
 def test_info_missing_preset():


### PR DESCRIPTION
# User description
## Summary
- Make Harbor-derived preset IDs versioned by default, e.g. `sbv-1.0-mswea` and `kumo-easy-mswea`.
- Register unversioned aliases only when they are unambiguous for a single Harbor dataset, preserving common IDs like `sbv-mswea` and `tbench-mswea`.
- Allow periods in preset names so versions like `1.0` remain human-readable.

## Ticket
ENG-1436

## Tests
- `uv run ruff check src/ares/presets.py src/ares/registry.py src/ares/registry_test.py`
- `uv run pytest -q src/ares/registry_test.py`
- `uv run pyright src/ares/presets.py src/ares/registry.py src/ares/registry_test.py`
- `git diff --check`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Version Harbor dataset IDs in <code>presets._register_default_presets</code> only when multiple versions share the same name while keeping short aliases for single-version datasets through the updated <code>_make_harbor_dataset_id</code> builder. Allow periods in the <code>registry</code> preset name validator so names with readable version numbers such as <code>1.0</code> pass validation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/103?tool=ast&topic=Harbor+versioning>Harbor versioning</a>
        </td><td>Update <code>presets._register_default_presets</code> to compute versioned Harbor IDs, register unique aliases for single-version datasets, and cover the behavior with registry tests.<details><summary>Modified files (2)</summary><ul><li>src/ares/presets.py</li>
<li>src/ares/registry_test.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Register unambiguous H...</td><td>June 04, 2026</td></tr>
<tr><td>Narmeen07</td><td>Add mechanistic interp...</td><td>February 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/103?tool=ast&topic=Preset+validation>Preset validation</a>
        </td><td>Allow periods in the <code>registry</code> preset name validator so human-readable versions stay valid.<details><summary>Modified files (1)</summary><ul><li>src/ares/registry.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Version duplicate Harb...</td><td>June 04, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Massively simplify the...</td><td>January 29, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/withmartian/ares/103?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Preset names now allow periods (`.`) for more flexible naming.

* **Improvements**
  * Harbor dataset identifiers now include versioning when needed and will register unversioned aliases only for unambiguous names to avoid collisions.

* **Tests**
  * Added a test validating versioned vs. unambiguous alias registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->