### PR TITLE
Bump ARES to 0.1.0 and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to ARES will be documented in this file.
+
+ARES follows semantic versioning, but `0.y.z` releases are initial development and may include breaking changes.
+
+## [0.1.0] - 2026-06-05
+
+### Added
+
+- Added the ARES proxy for HTTP-mediated LLM request interception.
+- Added SkyRL integration example.
+- Added a transformers-backed local LLM client in `ares.contrib`.
+- Added mechanistic interpretability tooling and a 20Q case study.
+- Added explicit Daytona configuration support for container factories.
+
+### Changed
+
+- Versioned duplicate Harbor-derived registry preset IDs so task names disambiguate dataset versions.
+- Refactored LLM request conversion into dedicated converter modules.
+- Switched SWE-bench runs to the repo-owned mini-swe-agent configuration.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,6 +3,7 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import importlib.metadata
 import os
 import sys
 
@@ -16,8 +17,7 @@ project = "ARES"
 copyright = "2026, Martian"
 author = "Martian"
 
-# Read version from installed package metadata
-release = "0.0.1"
+release = importlib.metadata.version("martian-ares")
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/ares"]
 
 [project]
 name = "martian-ares"
-version = "0.0.2"
+version = "0.1.0"
 authors = [
     {name = "Joshua Greaves", email = "josh@withmartian.com"},
     {name = "Ryan Smith", email = "ryan@withmartian.com"},
@@ -51,6 +51,7 @@ transformer-lens = ["transformer-lens>=2.10.0"]
 [project.urls]
 Homepage = "https://github.com/withmartian/ares"
 Repository = "https://github.com/withmartian/ares"
+Changelog = "https://github.com/withmartian/ares/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
# User description
## Summary
- Bump `martian-ares` package metadata to `0.1.0` and expose a changelog project URL.
- Add a root `CHANGELOG.md` covering the 0.1.0 release, including the registry task-name changes.
- Make Sphinx docs read the package version from installed metadata instead of a stale hardcoded value.

## Ticket
[ENG-1438](https://linear.app/withmartian/issue/ENG-1438/bump-ares-version-and-add-changelog)

## Tests
- `uv run ruff format docs/source/conf.py`
- `uv run ruff check docs/source/conf.py`
- `uv run python -c "import importlib.metadata; assert importlib.metadata.version('martian-ares') == '0.1.0'"`
- `uv run python -c "import importlib.util; spec = importlib.util.spec_from_file_location('docs_conf', 'docs/source/conf.py'); module = importlib.util.module_from_spec(spec); assert spec.loader is not None; spec.loader.exec_module(module); assert module.release == '0.1.0'"`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the <code>martian-ares</code> release metadata and changelog to capture the 0.1.0 highlights and expose the project changelog URL. Load the release value for the Sphinx configuration directly from installed metadata to keep the docs in sync with the package.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/105?tool=ast&topic=Docs+versioning>Docs versioning</a>
        </td><td>Read release metadata from <code>martian-ares</code> when configuring Sphinx so the docs always report the current package version.<details><summary>Modified files (1)</summary><ul><li>docs/source/conf.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Bump ARES to 0.1.0</td><td>June 05, 2026</td></tr>
<tr><td>ryanscais3@gmail.com</td><td>Add initial docs (#52)</td><td>January 28, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/105?tool=ast&topic=Release+metadata>Release metadata</a>
        </td><td>Document the 0.1.0 release by raising <code>martian-ares</code> version metadata, linking the changelog URL, and recording the release highlights and registry task-name changes.<details><summary>Modified files (2)</summary><ul><li>CHANGELOG.md</li>
<li>pyproject.toml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Bump ARES to 0.1.0</td><td>June 05, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Use repo-owned mini-sw...</td><td>June 05, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/withmartian/ares/105?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP proxy interception capability
  * Added SkyRL integration example
  * Added local LLM client support
  * Added mechanistic interpretability tooling with 20Q case study
  * Added Daytona configuration support

* **Chores**
  * Version bumped to 0.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->