### PR TITLE
Use Terminal-Bench Mini-SWE config

### DIFF
--- a/src/ares/code_agents/configs/mini_swe_v1_14_4.yaml
+++ b/src/ares/code_agents/configs/mini_swe_v1_14_4.yaml
@@ -1,3 +1,6 @@
+# Copied from mini-swe-agent==1.14.4: minisweagent/config/mini.yaml
+# ARES owns this copy so MiniSWECodeAgent's default text-based behavior does not depend on
+# mini-swe-agent's bundled config layout or later tool-call-oriented config changes.
 agent:
   system_template: |
     You are a helpful assistant that can interact with a computer.

--- a/src/ares/code_agents/configs/mini_swe_v1_14_4.yaml
+++ b/src/ares/code_agents/configs/mini_swe_v1_14_4.yaml
@@ -1,0 +1,160 @@
+agent:
+  system_template: |
+    You are a helpful assistant that can interact with a computer.
+
+    Your response must contain exactly ONE bash code block with ONE command (or commands connected with && or ||).
+    Include a THOUGHT section before your command where you explain your reasoning process.
+    Format your response as shown in <format_example>.
+
+    <format_example>
+    Your reasoning and analysis here. Explain why you want to perform the action.
+
+    ```bash
+    your_command_here
+    ```
+    </format_example>
+
+    Failure to follow these rules will cause your response to be rejected.
+  instance_template: |
+    Please solve this issue: {{task}}
+
+    You can execute bash commands and edit files to implement the necessary changes.
+
+    ## Recommended Workflow
+
+    This workflows should be done step-by-step so that you can iterate on your changes and any possible problems.
+
+    1. Analyze the codebase by finding and reading relevant files
+    2. Create a script to reproduce the issue
+    3. Edit the source code to resolve the issue
+    4. Verify your fix works by running your script again
+    5. Test edge cases to ensure your fix is robust
+    6. Submit your changes and finish your work by issuing the following command: `echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT`.
+       Do not combine it with any other command. <important>After this command, you cannot continue working on this task.</important>
+
+    ## Important Rules
+
+    1. Every response must contain exactly one action
+    2. The action must be enclosed in triple backticks
+    3. Directory or environment variable changes are not persistent. Every action is executed in a new subshell.
+       However, you can prefix any action with `MY_ENV_VAR=MY_VALUE cd /path/to/working/dir && ...` or write/load environment variables from files
+
+    <system_information>
+    {{system}} {{release}} {{version}} {{machine}}
+    </system_information>
+
+    ## Formatting your response
+
+    Here is an example of a correct response:
+
+    <example_response>
+    THOUGHT: I need to understand the structure of the repository first. Let me check what files are in the current directory to get a better understanding of the codebase.
+
+    ```bash
+    ls -la
+    ```
+    </example_response>
+
+    ## Useful command examples
+
+    ### Create a new file:
+
+    ```bash
+    cat <<'EOF' > newfile.py
+    import numpy as np
+    hello = "world"
+    print(hello)
+    EOF
+    ```
+
+    ### Edit files with sed:
+
+    {%- if system == "Darwin" -%}
+    <important>
+    You are on MacOS. For all the below examples, you need to use `sed -i ''` instead of `sed -i`.
+    </important>
+    {%- endif -%}
+
+    ```bash
+    # Replace all occurrences
+    sed -i 's/old_string/new_string/g' filename.py
+
+    # Replace only first occurrence
+    sed -i 's/old_string/new_string/' filename.py
+
+    # Replace first occurrence on line 1
+    sed -i '1s/old_string/new_string/' filename.py
+
+    # Replace all occurrences in lines 1-10
+    sed -i '1,10s/old_string/new_string/g' filename.py
+    ```
+
+    ### View file content:
+
+    ```bash
+    # View specific lines with numbers
+    nl -ba filename.py | sed -n '10,20p'
+    ```
+
+    ### Any other command you want to run
+
+    ```bash
+    anything
+    ```
+  action_observation_template: |
+    <returncode>{{output.returncode}}</returncode>
+    {% if output.output | length < 10000 -%}
+    <output>
+    {{ output.output -}}
+    </output>
+    {%- else -%}
+    <warning>
+    The output of your last command was too long.
+    Please try a different command that produces less output.
+    If you're looking at a file you can try use head, tail or sed to view a smaller number of lines selectively.
+    If you're using grep or find and it produced too much output, you can use a more selective search pattern.
+    If you really need to see something from the full command's output, you can redirect output to a file and then search in that file.
+    </warning>
+    {%- set elided_chars = output.output | length - 10000 -%}
+    <output_head>
+    {{ output.output[:5000] }}
+    </output_head>
+    <elided_chars>
+    {{ elided_chars }} characters elided
+    </elided_chars>
+    <output_tail>
+    {{ output.output[-5000:] }}
+    </output_tail>
+    {%- endif -%}
+  format_error_template: |
+    Please always provide EXACTLY ONE action in triple backticks, found {{actions|length}} actions.
+    If you want to end the task, please issue the following command: `echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT`
+    without any other command.
+    Else, please format your response exactly as follows:
+
+    <response_example>
+    Here are some thoughts about why you want to perform the action.
+
+    ```bash
+    <action>
+    ```
+    </response_example>
+
+    Note: In rare cases, if you need to reference a similar format in your command, you might have
+    to proceed in two steps, first writing TRIPLEBACKTICKSBASH, then replacing them with ```bash.
+  step_limit: 0.
+  cost_limit: 3.
+  mode: confirm
+environment:
+  timeout: 30
+  system_command: uname -s
+  env:
+    PAGER: cat
+    MANPAGER: cat
+    LESS: -R
+    PIP_PROGRESS_BAR: 'off'
+    TQDM_DISABLE: '1'
+model:
+  model_kwargs:
+    temperature: 0.0
+    drop_params: true

--- a/src/ares/code_agents/mini_swe_agent.py
+++ b/src/ares/code_agents/mini_swe_agent.py
@@ -123,7 +123,7 @@ class MiniSWECodeAgent(code_agent_base.CodeAgent):
     container: containers.Container
     llm_client: llm_clients.LLMClient
     tracker: stat_tracker.StatTracker = dataclasses.field(default_factory=stat_tracker.NullStatTracker)
-    config_name: str = SWEBENCH_CONFIG_NAME
+    config_name: str = MINI_SWE_V1_14_4_CONFIG_NAME
 
     def __post_init__(self):
         config_resource = _CONFIGS_RESOURCE / self.config_name

--- a/src/ares/code_agents/mini_swe_agent.py
+++ b/src/ares/code_agents/mini_swe_agent.py
@@ -28,7 +28,10 @@ from ares.llms import request
 from ares.llms import response
 
 _LOGGER = logging.getLogger(__name__)
-_SWEBENCH_CONFIG_RESOURCE = importlib.resources.files("ares.code_agents") / "configs" / "swebench_v1.yaml"
+SWEBENCH_CONFIG_NAME = "swebench_v1.yaml"
+MINI_SWE_V1_14_4_CONFIG_NAME = "mini_swe_v1_14_4.yaml"
+_CONFIGS_RESOURCE = importlib.resources.files("ares.code_agents") / "configs"
+_SWEBENCH_CONFIG_RESOURCE = _CONFIGS_RESOURCE / SWEBENCH_CONFIG_NAME
 _AGENT_CONFIG_KEYS = frozenset(
     {
         "action_observation_template",
@@ -120,14 +123,17 @@ class MiniSWECodeAgent(code_agent_base.CodeAgent):
     container: containers.Container
     llm_client: llm_clients.LLMClient
     tracker: stat_tracker.StatTracker = dataclasses.field(default_factory=stat_tracker.NullStatTracker)
+    config_name: str = SWEBENCH_CONFIG_NAME
 
     def __post_init__(self):
-        self._config = yaml.safe_load(_SWEBENCH_CONFIG_RESOURCE.read_text(encoding="utf-8"))
+        config_resource = _CONFIGS_RESOURCE / self.config_name
+        self._config = yaml.safe_load(config_resource.read_text(encoding="utf-8"))
         self._agent_config = self._config.get("agent", {})
 
         environment_config = self._config.get("environment", {})
         self._env_timeout = environment_config.get("timeout", None)
         self._environment_env_vars = environment_config.get("env", None)
+        self._system_command = environment_config.get("system_command", "uname -a")
 
         for k in self._config.get("agent", {}):
             if k not in _AGENT_CONFIG_KEYS:
@@ -157,7 +163,9 @@ class MiniSWECodeAgent(code_agent_base.CodeAgent):
         with self.tracker.timeit("mswea/setup"):
             _LOGGER.debug("[%d] Starting mini-swe-agent run.", id(self))
 
-            system = (await self.container.exec_run("uname -a", env=self._environment_env_vars)).output.strip()
+            system = (
+                await self.container.exec_run(self._system_command, env=self._environment_env_vars)
+            ).output.strip()
             release = (await self.container.exec_run("uname -r", env=self._environment_env_vars)).output.strip()
             version = (await self.container.exec_run("uname -v", env=self._environment_env_vars)).output.strip()
             machine = (await self.container.exec_run("uname -m", env=self._environment_env_vars)).output.strip()

--- a/src/ares/environments/code_env.py
+++ b/src/ares/environments/code_env.py
@@ -33,6 +33,7 @@ from ares.llms import request
 from ares.llms import response
 
 _LOGGER = logging.getLogger(__name__)
+DEFAULT_STEP_LIMIT = 250
 
 
 @functools.lru_cache(maxsize=1)
@@ -64,7 +65,7 @@ class CodeEnvironment(base.Environment[response.LLMResponse, request.LLMRequest 
         *,
         container_factory: containers.ContainerFactory = ares_daytona.DaytonaContainer,
         code_agent_factory: code_agent_base.CodeAgentFactory = mini_swe_agent.MiniSWECodeAgent,
-        step_limit: int = 250,  # Same as mini-swe-agent default.
+        step_limit: int = DEFAULT_STEP_LIMIT,
         prefix: str = "harbor_env",
         tracker: stat_tracker.StatTracker | None = None,
     ):
@@ -145,7 +146,7 @@ class CodeEnvironment(base.Environment[response.LLMResponse, request.LLMRequest 
         with self._tracker.timeit(f"{self._prefix}/get_time_step"):
             ts = await self._get_time_step()
 
-        if self._step_count >= self._step_limit:
+        if 0 < self._step_limit <= self._step_count:
             _LOGGER.debug("[%d] Step limit reached. Returning LAST timestep.", id(self))
             assert self._code_agent_task is not None
             self._code_agent_task.cancel()

--- a/src/ares/presets.py
+++ b/src/ares/presets.py
@@ -40,10 +40,10 @@ def _make_harbor_dataset_id(name: str, version: str | None = None) -> str:
 
 def _make_mswea_factory(ds_spec: harbor_registry.DatasetSpec) -> code_agent_base.CodeAgentFactory:
     """Return the Mini-SWE agent factory with the right dataset prompt config."""
-    if ds_spec.name == "terminal-bench":
+    if ds_spec.name == "swebench-verified":
         return functools.partial(
             mini_swe_agent.MiniSWECodeAgent,
-            config_name=mini_swe_agent.MINI_SWE_V1_14_4_CONFIG_NAME,
+            config_name=mini_swe_agent.SWEBENCH_CONFIG_NAME,
         )
 
     return mini_swe_agent.MiniSWECodeAgent
@@ -57,6 +57,7 @@ class HarborSpec:
     dataset_id: str
     code_agent_factory: code_agent_base.CodeAgentFactory
     code_agent_id: str
+    step_limit: int = code_env.DEFAULT_STEP_LIMIT
 
     @functools.cached_property
     def ds(self) -> list[harbor_task.Task]:
@@ -90,7 +91,7 @@ class HarborSpec:
             tasks=selected_tasks,
             container_factory=container_factory,
             code_agent_factory=self.code_agent_factory,
-            step_limit=250,  # Same as mini-swe-agent default.
+            step_limit=self.step_limit,
             tracker=tracker,
         )
 
@@ -145,9 +146,9 @@ def _register_default_presets() -> None:
         ds_id = _make_harbor_dataset_id(ds_spec.name, ds_spec.version)
         alias_ds_id = _make_harbor_dataset_id(ds_spec.name)
 
-        for code_agent_id, code_agent_factory in [
-            ("mswea", _make_mswea_factory(ds_spec)),
-            ("terminus2", terminus2_agent.Terminus2Agent),
+        for code_agent_id, code_agent_factory, step_limit in [
+            ("mswea", _make_mswea_factory(ds_spec), 0),
+            ("terminus2", terminus2_agent.Terminus2Agent, code_env.DEFAULT_STEP_LIMIT),
         ]:
             registry.register_preset(
                 f"{ds_id}-{code_agent_id}",
@@ -156,6 +157,7 @@ def _register_default_presets() -> None:
                     dataset_id=ds_id,
                     code_agent_factory=code_agent_factory,
                     code_agent_id=code_agent_id,
+                    step_limit=step_limit,
                 ),
             )
             if alias_id_counts[alias_ds_id] == 1:
@@ -166,6 +168,7 @@ def _register_default_presets() -> None:
                         dataset_id=alias_ds_id,
                         code_agent_factory=code_agent_factory,
                         code_agent_id=code_agent_id,
+                        step_limit=step_limit,
                     ),
                 )
 

--- a/src/ares/presets.py
+++ b/src/ares/presets.py
@@ -38,6 +38,17 @@ def _make_harbor_dataset_id(name: str, version: str | None = None) -> str:
     return f"{dataset_id}-{version}"
 
 
+def _make_mswea_factory(ds_spec: harbor_registry.DatasetSpec) -> code_agent_base.CodeAgentFactory:
+    """Return the Mini-SWE agent factory with the right dataset prompt config."""
+    if ds_spec.name == "terminal-bench":
+        return functools.partial(
+            mini_swe_agent.MiniSWECodeAgent,
+            config_name=mini_swe_agent.MINI_SWE_V1_14_4_CONFIG_NAME,
+        )
+
+    return mini_swe_agent.MiniSWECodeAgent
+
+
 @dataclasses.dataclass(frozen=True)
 class HarborSpec:
     """Environment spec for Harbor Verified with mini-swe-agent."""
@@ -135,7 +146,7 @@ def _register_default_presets() -> None:
         alias_ds_id = _make_harbor_dataset_id(ds_spec.name)
 
         for code_agent_id, code_agent_factory in [
-            ("mswea", mini_swe_agent.MiniSWECodeAgent),
+            ("mswea", _make_mswea_factory(ds_spec)),
             ("terminus2", terminus2_agent.Terminus2Agent),
         ]:
             registry.register_preset(

--- a/src/ares/registry_test.py
+++ b/src/ares/registry_test.py
@@ -2,11 +2,13 @@
 
 from collections.abc import Sequence
 import dataclasses
+import functools
 from typing import Any
 
 import pytest
 
 from ares import registry
+from ares.code_agents import mini_swe_agent
 from ares.containers import containers
 from ares.containers import docker
 from ares.experiment_tracking import stat_tracker
@@ -113,6 +115,18 @@ def test_register_default_presets_versions_and_unambiguous_aliases(monkeypatch):
         assert "sbv-mswea" in preset_names
         assert "tbench-mswea" in preset_names
         assert "20q" in preset_names
+
+        tbench_spec = registry._REGISTRY["tbench-latest-mswea"]
+        assert isinstance(tbench_spec, presets.HarborSpec)
+        assert isinstance(tbench_spec.code_agent_factory, functools.partial)
+        assert tbench_spec.code_agent_factory.func is mini_swe_agent.MiniSWECodeAgent
+        assert tbench_spec.code_agent_factory.keywords == {
+            "config_name": mini_swe_agent.MINI_SWE_V1_14_4_CONFIG_NAME,
+        }
+
+        sbv_spec = registry._REGISTRY["sbv-latest-mswea"]
+        assert isinstance(sbv_spec, presets.HarborSpec)
+        assert sbv_spec.code_agent_factory is mini_swe_agent.MiniSWECodeAgent
     finally:
         registry._REGISTRY.clear()
         registry._REGISTRY.update(original_registry)

--- a/src/ares/registry_test.py
+++ b/src/ares/registry_test.py
@@ -1,5 +1,6 @@
 """Tests for the registry system."""
 
+import asyncio
 from collections.abc import Sequence
 import dataclasses
 import functools
@@ -11,7 +12,10 @@ from ares import registry
 from ares.code_agents import mini_swe_agent
 from ares.containers import containers
 from ares.containers import docker
+from ares.environments import base
+from ares.environments import code_env
 from ares.experiment_tracking import stat_tracker
+from ares.llms import response
 
 
 @dataclasses.dataclass(frozen=True)
@@ -93,6 +97,8 @@ def test_register_default_presets_versions_and_unambiguous_aliases(monkeypatch):
         _FakeHarborDatasetSpec(name="kumo", version="easy", tasks=(object(),)),
         _FakeHarborDatasetSpec(name="swebench-verified", version="latest", tasks=(object(),)),
         _FakeHarborDatasetSpec(name="terminal-bench", version="latest", tasks=(object(),)),
+        _FakeHarborDatasetSpec(name="terminal-bench-sample", version="2.0", tasks=(object(),)),
+        _FakeHarborDatasetSpec(name="terminal-bench-pro", version="1.0", tasks=(object(),)),
     )
     original_registry = dict(registry._REGISTRY)
     monkeypatch.setattr(presets.code_env, "list_harbor_datasets", lambda: fake_ds_specs)
@@ -110,6 +116,8 @@ def test_register_default_presets_versions_and_unambiguous_aliases(monkeypatch):
         assert "kumo-easy-terminus2" in preset_names
         assert "sbv-latest-mswea" in preset_names
         assert "tbench-latest-mswea" in preset_names
+        assert "tbench-sample-2.0-mswea" in preset_names
+        assert "tbench-pro-1.0-mswea" in preset_names
         assert "kumo-mswea" not in preset_names
         assert "kumo-terminus2" not in preset_names
         assert "sbv-mswea" in preset_names
@@ -118,18 +126,62 @@ def test_register_default_presets_versions_and_unambiguous_aliases(monkeypatch):
 
         tbench_spec = registry._REGISTRY["tbench-latest-mswea"]
         assert isinstance(tbench_spec, presets.HarborSpec)
-        assert isinstance(tbench_spec.code_agent_factory, functools.partial)
-        assert tbench_spec.code_agent_factory.func is mini_swe_agent.MiniSWECodeAgent
-        assert tbench_spec.code_agent_factory.keywords == {
-            "config_name": mini_swe_agent.MINI_SWE_V1_14_4_CONFIG_NAME,
-        }
+        assert tbench_spec.code_agent_factory is mini_swe_agent.MiniSWECodeAgent
+        assert tbench_spec.step_limit == 0
+
+        tbench_sample_spec = registry._REGISTRY["tbench-sample-2.0-mswea"]
+        assert isinstance(tbench_sample_spec, presets.HarborSpec)
+        assert tbench_sample_spec.code_agent_factory is mini_swe_agent.MiniSWECodeAgent
+        assert tbench_sample_spec.step_limit == 0
+
+        tbench_pro_spec = registry._REGISTRY["tbench-pro-1.0-mswea"]
+        assert isinstance(tbench_pro_spec, presets.HarborSpec)
+        assert tbench_pro_spec.code_agent_factory is mini_swe_agent.MiniSWECodeAgent
+        assert tbench_pro_spec.step_limit == 0
 
         sbv_spec = registry._REGISTRY["sbv-latest-mswea"]
         assert isinstance(sbv_spec, presets.HarborSpec)
-        assert sbv_spec.code_agent_factory is mini_swe_agent.MiniSWECodeAgent
+        assert isinstance(sbv_spec.code_agent_factory, functools.partial)
+        assert sbv_spec.code_agent_factory.func is mini_swe_agent.MiniSWECodeAgent
+        assert sbv_spec.code_agent_factory.keywords == {
+            "config_name": mini_swe_agent.SWEBENCH_CONFIG_NAME,
+        }
+        assert sbv_spec.step_limit == 0
+
+        tbench_terminus2_spec = registry._REGISTRY["tbench-latest-terminus2"]
+        assert isinstance(tbench_terminus2_spec, presets.HarborSpec)
+        assert tbench_terminus2_spec.step_limit == presets.code_env.DEFAULT_STEP_LIMIT
     finally:
         registry._REGISTRY.clear()
         registry._REGISTRY.update(original_registry)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("step_limit", "expected_step_type"), [(0, "MID"), (1, "LAST")])
+async def test_code_environment_step_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    step_limit: int,
+    expected_step_type: base.StepType,
+) -> None:
+    env = code_env.CodeEnvironment(tasks=(), step_limit=step_limit)
+
+    async def get_time_step() -> base.TimeStep[None, float, float]:
+        return base.TimeStep(step_type="MID", reward=0.0, discount=1.0, observation=None)
+
+    monkeypatch.setattr(env, "_get_time_step", get_time_step)
+
+    async with env:
+        env._llm_req_future = asyncio.get_running_loop().create_future()
+        env._code_agent_task = asyncio.create_task(asyncio.sleep(60))
+        result = await env.step(
+            response.LLMResponse(
+                data=[response.TextData(content="")],
+                cost=0.0,
+                usage=response.Usage(prompt_tokens=0, generated_tokens=0),
+            )
+        )
+
+        assert result.step_type == expected_step_type
 
 
 def test_info_missing_preset():

--- a/src/mini_swe_agent_config_test.py
+++ b/src/mini_swe_agent_config_test.py
@@ -1,3 +1,4 @@
+import typing
 from unittest import mock
 
 from harbor.registry.client import factory as harbor_client_factory
@@ -11,6 +12,7 @@ _harbor_client.get_datasets.return_value = ()
 with mock.patch.object(harbor_client_factory.RegistryClientFactory, "create", return_value=_harbor_client):
     from ares.code_agents import mini_swe_agent
     from ares.containers import containers
+    from ares.llms import request
     from ares.llms import response
     from ares.testing.mock_container import MockContainer
     from ares.testing.mock_llm import MockLLMClient
@@ -40,6 +42,21 @@ def test_mini_swe_code_agent_initializes_from_repo_config() -> None:
     assert agent._environment_env_vars["PAGER"] == "cat"
 
 
+def test_mini_swe_code_agent_initializes_from_terminal_bench_config() -> None:
+    agent = mini_swe_agent.MiniSWECodeAgent(
+        container=MockContainer(),
+        llm_client=MockLLMClient(),
+        config_name=mini_swe_agent.MINI_SWE_V1_14_4_CONFIG_NAME,
+    )
+
+    assert agent._system_prompt.startswith("You are a helpful assistant")
+    assert agent._step_limit == 0
+    assert agent._cost_limit == 3.0
+    assert agent._env_timeout == 30
+    assert agent._system_command == "uname -s"
+    assert "echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT`." in agent._agent_config["instance_template"]
+
+
 @pytest.mark.asyncio
 async def test_mini_swe_code_agent_uses_agent_observation_template() -> None:
     container = MockContainer(exec_responses={"echo hi": containers.ExecResult(output="hi", exit_code=0)})
@@ -53,8 +70,9 @@ async def test_mini_swe_code_agent_uses_agent_observation_template() -> None:
         )
     )
 
-    assert "<returncode>0</returncode>" in agent._messages[-1]["content"]
-    assert "hi" in agent._messages[-1]["content"]
+    message = typing.cast(request.UserMessage, agent._messages[-1])
+    assert "<returncode>0</returncode>" in message["content"]
+    assert "hi" in message["content"]
 
 
 def test_mini_swe_code_agent_uses_agent_format_error_template() -> None:

--- a/src/mini_swe_agent_config_test.py
+++ b/src/mini_swe_agent_config_test.py
@@ -32,29 +32,30 @@ def test_agent_config_keys_match_v1_agent_section() -> None:
     assert frozenset(config["agent"]) == mini_swe_agent._AGENT_CONFIG_KEYS
 
 
-def test_mini_swe_code_agent_initializes_from_repo_config() -> None:
+def test_mini_swe_code_agent_initializes_from_default_config() -> None:
     agent = mini_swe_agent.MiniSWECodeAgent(container=MockContainer(), llm_client=MockLLMClient())
-
-    assert agent._system_prompt.startswith("You are a helpful assistant")
-    assert agent._step_limit == 250
-    assert agent._cost_limit == 3.0
-    assert agent._env_timeout == 60
-    assert agent._environment_env_vars["PAGER"] == "cat"
-
-
-def test_mini_swe_code_agent_initializes_from_terminal_bench_config() -> None:
-    agent = mini_swe_agent.MiniSWECodeAgent(
-        container=MockContainer(),
-        llm_client=MockLLMClient(),
-        config_name=mini_swe_agent.MINI_SWE_V1_14_4_CONFIG_NAME,
-    )
 
     assert agent._system_prompt.startswith("You are a helpful assistant")
     assert agent._step_limit == 0
     assert agent._cost_limit == 3.0
     assert agent._env_timeout == 30
     assert agent._system_command == "uname -s"
-    assert "echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT`." in agent._agent_config["instance_template"]
+    assert agent._environment_env_vars["PAGER"] == "cat"
+
+
+def test_mini_swe_code_agent_initializes_from_swebench_config() -> None:
+    agent = mini_swe_agent.MiniSWECodeAgent(
+        container=MockContainer(),
+        llm_client=MockLLMClient(),
+        config_name=mini_swe_agent.SWEBENCH_CONFIG_NAME,
+    )
+
+    assert agent._system_prompt.startswith("You are a helpful assistant")
+    assert agent._step_limit == 250
+    assert agent._cost_limit == 3.0
+    assert agent._env_timeout == 60
+    assert agent._system_command == "uname -a"
+    assert "Regular source code files in /testbed" in agent._agent_config["instance_template"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# User description
## Summary
- Keep a single Mini-SWE code agent implementation while allowing it to load dataset-specific configs.
- Add the Mini-SWE 1.14.4 default config used by Terminal-Bench references.
- Wire Terminal-Bench `mswea` presets to use the 1.14.4 config while preserving the existing SWE-bench config elsewhere.

## Testing
- `uv run pytest src/ares/registry_test.py src/mini_swe_agent_config_test.py`
- `uv run ruff check src/ares/code_agents/mini_swe_agent.py src/ares/presets.py src/ares/registry_test.py src/mini_swe_agent_config_test.py`
- `uv run ruff format --check src/ares/code_agents/mini_swe_agent.py src/ares/presets.py src/ares/registry_test.py src/mini_swe_agent_config_test.py`
- `uv run pyright src/ares/code_agents/mini_swe_agent.py src/ares/presets.py src/ares/registry_test.py src/mini_swe_agent_config_test.py`

## Notes
Full `uv run pyright` still reports pre-existing optional dependency/type errors in examples and contrib files outside this change.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Route <code>MiniSWECodeAgent</code> through dataset-specific prompt configs so <code>mswea</code> presets can use the copied Mini-SWE 1.14.4 behavior for Terminal-Bench while <code>swebench-verified</code> keeps the SWE-bench config. Update <code>CodeEnvironment</code> and <code>HarborSpec</code> to carry preset step limits, with <code>mswea</code> running without a cap and other presets retaining the default.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/108?tool=ast&topic=Step+limits>Step limits</a>
        </td><td>Allow <code>CodeEnvironment</code> to treat a step limit of <code>0</code> as unlimited and thread preset-specific limits through <code>HarborSpec</code>.<details><summary>Modified files (3)</summary><ul><li>src/ares/environments/code_env.py</li>
<li>src/ares/presets.py</li>
<li>src/ares/registry_test.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Use generic Mini-SWE c...</td><td>July 27, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Use Terminal-Bench Min...</td><td>July 24, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/108?tool=ast&topic=Preset+routing>Preset routing</a>
        </td><td>Route <code>MiniSWECodeAgent</code> and <code>presets</code> to load the right config per dataset, using the new Mini-SWE 1.14.4 YAML for Terminal-Bench and the SWE-bench config for <code>swebench-verified</code>.<details><summary>Modified files (5)</summary><ul><li>src/ares/code_agents/configs/mini_swe_v1_14_4.yaml</li>
<li>src/ares/code_agents/mini_swe_agent.py</li>
<li>src/ares/presets.py</li>
<li>src/ares/registry_test.py</li>
<li>src/mini_swe_agent_config_test.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Use generic Mini-SWE c...</td><td>July 27, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Use Terminal-Bench Min...</td><td>July 24, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/withmartian/ares/108?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Mini-SWE agent prompt and runtime settings.
  * Added dataset-aware agent selection for supported benchmark presets.
  * Added per-environment step-limit configuration.
  * Added support for selecting the system-information command.

* **Bug Fixes**
  * Corrected step-limit handling when limits are disabled or customized.

* **Tests**
  * Expanded coverage for preset registration, agent configuration, environment limits, and system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->