### PR TITLE
Add OpenCode agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+Use the corresponding `-opencode` preset, such as `sbv-opencode`, to run OpenCode inside the task sandbox. ARES installs OpenCode, configures it to use the in-sandbox ARES proxy through the OpenAI Responses API, and exposes each OpenCode model request through the same `reset()`/`step()` loop. Building the Linux proxy binary requires Go or Docker on the ARES client.
+
+OpenCode presets disable session-title generation so only task-relevant requests enter the RL loop. Episode artifacts are saved under `logs/`, including OpenCode JSONL, mediated request/action JSONL, proxy logs, and verifier output.
+
 To run the example above you'll need a Martian API key set in your `.env` file. To get a key:
 
 1) Go to https://app.withmartian.com

--- a/ares-proxy/README.md
+++ b/ares-proxy/README.md
@@ -1,8 +1,8 @@
 # ares-proxy
 
-A lightweight HTTP proxy server that intercepts OpenAI-compatible chat completion requests and routes them through a queue-mediated polling system. Designed for use with the ARES (Agentic Research and Evaluation Suite) framework to enable RL-based control of LLM interactions.
+A lightweight HTTP proxy server that intercepts LLM API requests and routes them through a queue-mediated polling system. Designed for use with the ARES (Agentic Research and Evaluation Suite) framework to enable RL-based control of LLM interactions.
 
-The proxy doesn't validate the request/response types; this should be handled by the clients.
+The proxy validates JSON syntax but not provider request/response schemas; schema validation belongs in the controller.
 
 ## Overview
 
@@ -22,8 +22,8 @@ This architecture enables the ARES RL loop to intercept and control LLM interact
 │ (Agent)     │         │              │         │ (RL Environment)│
 └─────────────┘         └──────────────┘         └─────────────────┘
      │                         │                          │
-     │ POST /v1/chat/          │ GET /poll                │
-     │   completions           │ (retrieve requests)      │
+     │ POST /v1/...            │ GET /poll                │
+     │ (blocks waiting)        │ (retrieve requests)      │
      │ (blocks waiting)        │◀─────────────────────────┤
      │                         │                          │
      │                         │ POST /respond            │
@@ -42,23 +42,27 @@ The core coordination engine that manages:
 
 #### HTTP Endpoints (`main.go`)
 
-1. **`POST /v1/chat/completions`**
-   - OpenAI-compatible endpoint for LLM clients
-   - Accepts standard chat completion requests
+1. **Intercepted LLM endpoints**
+   - `POST /v1/chat/completions` for OpenAI-compatible Chat Completions clients
+   - `POST /v1/responses` for OpenAI Responses clients
+   - `POST /v1/messages` for Anthropic Messages clients
+   - Accept raw request JSON without schema validation
    - Blocks until a response is available or timeout occurs
-   - Returns the response as JSON
+   - Returns the response using the content type supplied by the controller
 
 2. **`GET /poll`**
    - Retrieves all pending requests from the queue
    - Clears the queue atomically
    - Returns an array of pending requests, each containing:
      - `id`: Unique request identifier
+     - `endpoint`: The intercepted API path
      - `timestamp`: When the request was submitted
-     - `request`: The original request payload (chat completion JSON)
+     - `request`: The original request payload JSON
 
 3. **`POST /respond`**
    - Sends a response back to a waiting request
    - Requires request ID and response payload
+   - Accepts an optional `content_type`; `application/json` is the default and `text/event-stream` carries buffered SSE
    - Returns error if request ID not found (e.g., timed out)
 
 ## Configuration
@@ -96,9 +100,11 @@ go build -o ares-proxy
 PORT=9000 TIMEOUT_MINUTES=30 ./ares-proxy
 ```
 
+The proxy binds to localhost because its control endpoints are intentionally unauthenticated and are only used from within the sandbox.
+
 ### Client Usage
 
-Configure your LLM client to point at the proxy:
+Configure your LLM client to point at the proxy. The proxy currently intercepts Chat Completions, OpenAI Responses, and Anthropic Messages requests under `/v1`.
 
 ```python
 from openai import OpenAI
@@ -130,17 +136,19 @@ requests_list = response.json()
 
 for req in requests_list:
     request_id = req["id"]
+    endpoint = req["endpoint"]
     request_body = req["request"]
 
     # Process the request (e.g., send to real LLM)
-    llm_response = process_request(request_body)
+    llm_response = process_request(endpoint, request_body)
 
     # Send response back to waiting client
     requests.post(
         "http://localhost:8080/respond",
         json={
             "id": request_id,
-            "response": llm_response
+            "response": llm_response,
+            "content_type": "application/json",
         }
     )
 ```
@@ -166,6 +174,7 @@ Tests run automatically in CI via GitHub Actions when any files in `ares-proxy/`
 ```
 ares-proxy/
 ├── main.go         # HTTP server and endpoint handlers
+├── main_test.go    # HTTP endpoint tests
 ├── broker.go       # Core request/response coordination logic
 ├── broker_test.go  # Unit tests for broker
 ├── config.go       # Configuration loading
@@ -187,6 +196,8 @@ ares-proxy is designed to work with ARES's `QueueMediatedLLMClient`. The integra
 7. Proxy unblocks and returns response to code agent
 
 This architecture allows ARES to treat LLM interactions as part of the RL loop without agents needing to be modified.
+
+ARES actions are atomic rather than token streams. For streaming clients, the controller sends a complete SSE body to `/respond`; the proxy returns that buffered stream with `Content-Type: text/event-stream`.
 
 ## Error Handling
 

--- a/ares-proxy/broker.go
+++ b/ares-proxy/broker.go
@@ -13,7 +13,7 @@ import (
 // Broker manages pending requests and coordinates responses
 type Broker struct {
 	// pendingRequests maps request ID to a response channel
-	pendingRequests map[string]chan json.RawMessage
+	pendingRequests map[string]chan ProxyResponse
 	// requestQueue holds requests waiting to be polled
 	requestQueue []PendingRequest
 	// mu protects both maps from concurrent access
@@ -25,26 +25,27 @@ type Broker struct {
 // NewBroker creates a new broker with the given timeout
 func NewBroker(timeout time.Duration) *Broker {
 	return &Broker{
-		pendingRequests: make(map[string]chan json.RawMessage),
+		pendingRequests: make(map[string]chan ProxyResponse),
 		requestQueue:    make([]PendingRequest, 0),
 		timeout:         timeout,
 	}
 }
 
-// SubmitRequest adds a request to the queue and waits for a response
-// This is called by the /v1/chat/completions endpoint
-func (b *Broker) SubmitRequest(ctx context.Context, requestBody json.RawMessage) (json.RawMessage, error) {
+// SubmitRequest adds a request to the queue and waits for a response.
+// This is called by the intercepted LLM API endpoints.
+func (b *Broker) SubmitRequest(ctx context.Context, endpoint string, requestBody json.RawMessage) (ProxyResponse, error) {
 	// Generate a unique ID for this request
 	id := uuid.New().String()
 
 	// Create a channel to receive the response
-	responseChan := make(chan json.RawMessage, 1)
+	responseChan := make(chan ProxyResponse, 1)
 
 	// Add to pending requests
 	b.mu.Lock()
 	b.pendingRequests[id] = responseChan
 	b.requestQueue = append(b.requestQueue, PendingRequest{
 		ID:        id,
+		Endpoint:  endpoint,
 		Request:   requestBody,
 		Timestamp: time.Now(),
 	})
@@ -61,14 +62,14 @@ func (b *Broker) SubmitRequest(ctx context.Context, requestBody json.RawMessage)
 		delete(b.pendingRequests, id)
 		b.removePendingRequestFromQueue(id)
 		b.mu.Unlock()
-		return nil, fmt.Errorf("request timeout after %s", b.timeout)
+		return ProxyResponse{}, fmt.Errorf("request timeout after %s", b.timeout)
 	case <-ctx.Done():
 		// Client disconnected - clean up both map and queue
 		b.mu.Lock()
 		delete(b.pendingRequests, id)
 		b.removePendingRequestFromQueue(id)
 		b.mu.Unlock()
-		return nil, ctx.Err()
+		return ProxyResponse{}, ctx.Err()
 	}
 }
 
@@ -103,7 +104,7 @@ func (b *Broker) PollRequests() []PendingRequest {
 
 // RespondToRequest sends a response back to a waiting request
 // This is called by the /respond endpoint
-func (b *Broker) RespondToRequest(id string, response json.RawMessage) error {
+func (b *Broker) RespondToRequest(id string, response ProxyResponse) error {
 	b.mu.Lock()
 	responseChan, exists := b.pendingRequests[id]
 	if !exists {

--- a/ares-proxy/broker_test.go
+++ b/ares-proxy/broker_test.go
@@ -7,6 +7,10 @@ import (
 	"time"
 )
 
+func jsonProxyResponse(body json.RawMessage) ProxyResponse {
+	return ProxyResponse{Body: body, ContentType: "application/json"}
+}
+
 func TestBroker_SubmitAndPoll(t *testing.T) {
 	broker := NewBroker(1 * time.Minute)
 
@@ -14,10 +18,10 @@ func TestBroker_SubmitAndPoll(t *testing.T) {
 	testRequest := json.RawMessage(`{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}`)
 
 	// Submit request in background
-	responseChan := make(chan json.RawMessage, 1)
+	responseChan := make(chan ProxyResponse, 1)
 	go func() {
 		ctx := context.Background()
-		response, err := broker.SubmitRequest(ctx, testRequest)
+		response, err := broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
 		if err != nil {
 			t.Errorf("SubmitRequest failed: %v", err)
 			return
@@ -37,10 +41,13 @@ func TestBroker_SubmitAndPoll(t *testing.T) {
 	if string(pending[0].Request) != string(testRequest) {
 		t.Errorf("Request mismatch: got %s, want %s", pending[0].Request, testRequest)
 	}
+	if pending[0].Endpoint != "/v1/chat/completions" {
+		t.Errorf("Endpoint mismatch: got %s, want /v1/chat/completions", pending[0].Endpoint)
+	}
 
 	// Send response
 	testResponse := json.RawMessage(`{"id": "test", "choices": [{"message": {"role": "assistant", "content": "Hi"}}]}`)
-	err := broker.RespondToRequest(pending[0].ID, testResponse)
+	err := broker.RespondToRequest(pending[0].ID, jsonProxyResponse(testResponse))
 	if err != nil {
 		t.Fatalf("RespondToRequest failed: %v", err)
 	}
@@ -48,8 +55,8 @@ func TestBroker_SubmitAndPoll(t *testing.T) {
 	// Verify the original SubmitRequest call received the response
 	select {
 	case response := <-responseChan:
-		if string(response) != string(testResponse) {
-			t.Errorf("Response mismatch: got %s, want %s", response, testResponse)
+		if string(response.Body) != string(testResponse) {
+			t.Errorf("Response mismatch: got %s, want %s", response.Body, testResponse)
 		}
 	case <-time.After(1 * time.Second):
 		t.Fatal("Timeout waiting for response")
@@ -60,15 +67,15 @@ func TestBroker_MultipleConcurrentRequests(t *testing.T) {
 	broker := NewBroker(1 * time.Minute)
 
 	numRequests := 5
-	responses := make([]chan json.RawMessage, numRequests)
+	responses := make([]chan ProxyResponse, numRequests)
 
 	// Submit multiple requests concurrently
 	for i := 0; i < numRequests; i++ {
-		responses[i] = make(chan json.RawMessage, 1)
+		responses[i] = make(chan ProxyResponse, 1)
 		go func(idx int) {
 			ctx := context.Background()
 			req := json.RawMessage(`{"request": "` + string(rune('A'+idx)) + `"}`)
-			response, err := broker.SubmitRequest(ctx, req)
+			response, err := broker.SubmitRequest(ctx, "/v1/chat/completions", req)
 			if err != nil {
 				t.Errorf("Submit %d failed: %v", idx, err)
 				return
@@ -89,7 +96,7 @@ func TestBroker_MultipleConcurrentRequests(t *testing.T) {
 	// Respond to all
 	testResponse := json.RawMessage(`{"response": "ok"}`)
 	for _, req := range pending {
-		err := broker.RespondToRequest(req.ID, testResponse)
+		err := broker.RespondToRequest(req.ID, jsonProxyResponse(testResponse))
 		if err != nil {
 			t.Errorf("Respond failed for %s: %v", req.ID, err)
 		}
@@ -120,7 +127,7 @@ func TestBroker_RespondToNonexistentRequest(t *testing.T) {
 	broker := NewBroker(1 * time.Minute)
 
 	testResponse := json.RawMessage(`{"response": "test"}`)
-	err := broker.RespondToRequest("nonexistent-id", testResponse)
+	err := broker.RespondToRequest("nonexistent-id", jsonProxyResponse(testResponse))
 	if err == nil {
 		t.Error("Expected error when responding to nonexistent request")
 	}
@@ -138,7 +145,7 @@ func TestBroker_Timeout(t *testing.T) {
 	ctx := context.Background()
 
 	// Submit will timeout because no one responds
-	_, err := broker.SubmitRequest(ctx, testRequest)
+	_, err := broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
 	if err == nil {
 		t.Fatal("Expected timeout error, got nil")
 	}
@@ -163,7 +170,7 @@ func TestBroker_ContextCancellation(t *testing.T) {
 	// Submit in background
 	errChan := make(chan error, 1)
 	go func() {
-		_, err := broker.SubmitRequest(ctx, testRequest)
+		_, err := broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
 		errChan <- err
 	}()
 
@@ -200,7 +207,7 @@ func TestBroker_PollClearsQueue(t *testing.T) {
 	go func() {
 		ctx := context.Background()
 		testRequest := json.RawMessage(`{"test": "request"}`)
-		broker.SubmitRequest(ctx, testRequest)
+		broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
 	}()
 
 	// Give it time to queue
@@ -228,7 +235,7 @@ func TestBroker_RequestTimestamp(t *testing.T) {
 	go func() {
 		ctx := context.Background()
 		testRequest := json.RawMessage(`{"test": "request"}`)
-		broker.SubmitRequest(ctx, testRequest)
+		broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
 	}()
 
 	// Give it time to queue
@@ -262,13 +269,13 @@ func TestBroker_ExactlyOnceDelivery(t *testing.T) {
 
 	// Submit all requests
 	go func() {
-		broker.SubmitRequest(ctx1, testRequest1)
+		broker.SubmitRequest(ctx1, "/v1/chat/completions", testRequest1)
 	}()
 	go func() {
-		broker.SubmitRequest(ctx2, testRequest2) // Will timeout
+		broker.SubmitRequest(ctx2, "/v1/chat/completions", testRequest2) // Will timeout
 	}()
 	go func() {
-		broker.SubmitRequest(ctx3, testRequest3)
+		broker.SubmitRequest(ctx3, "/v1/chat/completions", testRequest3)
 	}()
 
 	// Give them time to queue
@@ -288,7 +295,7 @@ func TestBroker_ExactlyOnceDelivery(t *testing.T) {
 
 	// Respond to request 1 only
 	testResponse := json.RawMessage(`{"response": "ok"}`)
-	err := broker.RespondToRequest(pending1[0].ID, testResponse)
+	err := broker.RespondToRequest(pending1[0].ID, jsonProxyResponse(testResponse))
 	if err != nil {
 		t.Errorf("Failed to respond to request 1: %v", err)
 	}
@@ -306,12 +313,12 @@ func TestBroker_ExactlyOnceDelivery(t *testing.T) {
 	}
 
 	// Verify we can't respond to timed-out or cancelled requests
-	err = broker.RespondToRequest(pending1[1].ID, testResponse)
+	err = broker.RespondToRequest(pending1[1].ID, jsonProxyResponse(testResponse))
 	if err == nil {
 		t.Error("Expected error when responding to timed-out request")
 	}
 
-	err = broker.RespondToRequest(pending1[2].ID, testResponse)
+	err = broker.RespondToRequest(pending1[2].ID, jsonProxyResponse(testResponse))
 	if err == nil {
 		t.Error("Expected error when responding to cancelled request")
 	}

--- a/ares-proxy/main.go
+++ b/ares-proxy/main.go
@@ -16,22 +16,28 @@ func main() {
 	// Create the broker
 	broker := NewBroker(config.Timeout)
 
-	// Set up HTTP routes
-	http.HandleFunc("/v1/chat/completions", handleChatCompletion(broker))
-	http.HandleFunc("/poll", handlePoll(broker))
-	http.HandleFunc("/respond", handleRespond(broker))
+	mux := http.NewServeMux()
+	registerRoutes(mux, broker)
 
 	// Start the server
-	addr := ":" + config.Port
+	addr := "127.0.0.1:" + config.Port
 	log.Printf("Server listening on %s", addr)
-	if err := http.ListenAndServe(addr, nil); err != nil {
+	if err := http.ListenAndServe(addr, mux); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
 }
 
-// handleChatCompletion handles POST /v1/chat/completions
-// This holds the request and waits for a response
-func handleChatCompletion(broker *Broker) http.HandlerFunc {
+func registerRoutes(mux *http.ServeMux, broker *Broker) {
+	mux.HandleFunc("/v1/chat/completions", handleLLMRequest(broker))
+	mux.HandleFunc("/v1/responses", handleLLMRequest(broker))
+	mux.HandleFunc("/v1/messages", handleLLMRequest(broker))
+	mux.HandleFunc("/poll", handlePoll(broker))
+	mux.HandleFunc("/respond", handleRespond(broker))
+}
+
+// handleLLMRequest handles intercepted LLM API requests.
+// This holds the request and waits for a response.
+func handleLLMRequest(broker *Broker) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -45,17 +51,25 @@ func handleChatCompletion(broker *Broker) http.HandlerFunc {
 			return
 		}
 		defer r.Body.Close()
+		if !json.Valid(body) {
+			http.Error(w, "Invalid JSON", http.StatusBadRequest)
+			return
+		}
 
 		// Submit the request and wait for response
-		response, err := broker.SubmitRequest(r.Context(), json.RawMessage(body))
+		response, err := broker.SubmitRequest(r.Context(), r.URL.Path, json.RawMessage(body))
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Request failed: %v", err), http.StatusInternalServerError)
 			return
 		}
 
 		// Send the response back to the client
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(response)
+		w.Header().Set("Content-Type", response.ContentType)
+		if response.ContentType == "text/event-stream" {
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+		}
+		w.Write(response.Body)
 	}
 }
 
@@ -97,8 +111,14 @@ func handleRespond(broker *Broker) http.HandlerFunc {
 		}
 		defer r.Body.Close()
 
+		proxyResponse, err := req.ProxyResponse()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid response: %v", err), http.StatusBadRequest)
+			return
+		}
+
 		// Send the response to the waiting request
-		if err := broker.RespondToRequest(req.ID, req.Response); err != nil {
+		if err := broker.RespondToRequest(req.ID, proxyResponse); err != nil {
 			http.Error(w, fmt.Sprintf("Failed to respond: %v", err), http.StatusNotFound)
 			return
 		}

--- a/ares-proxy/main_test.go
+++ b/ares-proxy/main_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type receivedResponse struct {
+	body        string
+	contentType string
+}
+
+func newTestServer(broker *Broker) *httptest.Server {
+	mux := http.NewServeMux()
+	registerRoutes(mux, broker)
+	return httptest.NewServer(mux)
+}
+
+func pollUntilRequest(t *testing.T, client *http.Client, serverURL string) PendingRequest {
+	t.Helper()
+
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(serverURL + "/poll")
+		if err != nil {
+			t.Fatalf("poll failed: %v", err)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			t.Fatalf("failed to read poll response: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("poll status = %d, body = %s", resp.StatusCode, body)
+		}
+
+		var pending []PendingRequest
+		if err := json.Unmarshal(body, &pending); err != nil {
+			t.Fatalf("failed to decode poll response: %v", err)
+		}
+		if len(pending) > 0 {
+			if len(pending) != 1 {
+				t.Fatalf("expected 1 pending request, got %d", len(pending))
+			}
+			return pending[0]
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal("timed out waiting for pending request")
+	return PendingRequest{}
+}
+
+func respondToRequest(
+	t *testing.T,
+	client *http.Client,
+	serverURL string,
+	id string,
+	response string,
+	contentType string,
+) {
+	t.Helper()
+
+	var responseValue any = json.RawMessage(response)
+	if contentType != "application/json" {
+		responseValue = response
+	}
+	body, err := json.Marshal(map[string]any{
+		"id":           id,
+		"response":     responseValue,
+		"content_type": contentType,
+	})
+	if err != nil {
+		t.Fatalf("failed to encode respond request: %v", err)
+	}
+	resp, err := client.Post(serverURL+"/respond", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("respond failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("failed to read respond response: %v", err)
+		}
+		t.Fatalf("respond status = %d, body = %s", resp.StatusCode, body)
+	}
+}
+
+func TestLLMEndpoints_RouteRawRequests(t *testing.T) {
+	testCases := []struct {
+		name        string
+		endpoint    string
+		request     string
+		response    string
+		contentType string
+	}{
+		{
+			name:        "chat completions",
+			endpoint:    "/v1/chat/completions",
+			request:     `{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`,
+			response:    `{"id":"chatcmpl-test","choices":[{"message":{"role":"assistant","content":"hi"}}]}`,
+			contentType: "application/json",
+		},
+		{
+			name:        "openai responses",
+			endpoint:    "/v1/responses",
+			request:     `{"model":"gpt-5","input":[{"role":"user","content":[{"type":"input_text","text":"hello"}]}],"stream":true}`,
+			response:    "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n",
+			contentType: "text/event-stream",
+		},
+		{
+			name:        "anthropic messages",
+			endpoint:    "/v1/messages",
+			request:     `{"model":"claude-sonnet","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}],"stream":true,"max_tokens":4096}`,
+			response:    `{"id":"msg-test","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}]}`,
+			contentType: "application/json",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			broker := NewBroker(1 * time.Minute)
+			server := newTestServer(broker)
+			defer server.Close()
+
+			responseChan := make(chan receivedResponse, 1)
+			errorChan := make(chan error, 1)
+			go func() {
+				resp, err := server.Client().Post(
+					server.URL+tc.endpoint,
+					"application/json",
+					bytes.NewBufferString(tc.request),
+				)
+				if err != nil {
+					errorChan <- err
+					return
+				}
+				defer resp.Body.Close()
+
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					errorChan <- err
+					return
+				}
+				if resp.StatusCode != http.StatusOK {
+					errorChan <- fmt.Errorf("status = %d, body = %s", resp.StatusCode, body)
+					return
+				}
+				responseChan <- receivedResponse{body: string(body), contentType: resp.Header.Get("Content-Type")}
+			}()
+
+			pending := pollUntilRequest(t, server.Client(), server.URL)
+			if pending.Endpoint != tc.endpoint {
+				t.Fatalf("endpoint = %q, want %q", pending.Endpoint, tc.endpoint)
+			}
+			if string(pending.Request) != tc.request {
+				t.Fatalf("request = %s, want %s", pending.Request, tc.request)
+			}
+
+			respondToRequest(t, server.Client(), server.URL, pending.ID, tc.response, tc.contentType)
+
+			select {
+			case err := <-errorChan:
+				t.Fatal(err)
+			case response := <-responseChan:
+				if response.body != tc.response {
+					t.Fatalf("response = %s, want %s", response.body, tc.response)
+				}
+				if response.contentType != tc.contentType {
+					t.Fatalf("content type = %q, want %q", response.contentType, tc.contentType)
+				}
+			case <-time.After(1 * time.Second):
+				t.Fatal("timed out waiting for LLM endpoint response")
+			}
+		})
+	}
+}
+
+func TestLLMEndpoints_RejectNonPost(t *testing.T) {
+	broker := NewBroker(1 * time.Minute)
+	server := newTestServer(broker)
+	defer server.Close()
+
+	for _, endpoint := range []string{"/v1/chat/completions", "/v1/responses", "/v1/messages"} {
+		t.Run(endpoint, func(t *testing.T) {
+			resp, err := server.Client().Get(server.URL + endpoint)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusMethodNotAllowed)
+			}
+		})
+	}
+}
+
+func TestLLMEndpoints_RejectInvalidJSON(t *testing.T) {
+	broker := NewBroker(1 * time.Minute)
+	server := newTestServer(broker)
+	defer server.Close()
+
+	resp, err := server.Client().Post(
+		server.URL+"/v1/responses",
+		"application/json",
+		bytes.NewBufferString("not-json"),
+	)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if pending := broker.PollRequests(); len(pending) != 0 {
+		t.Fatalf("invalid request was queued: %v", pending)
+	}
+}

--- a/ares-proxy/types.go
+++ b/ares-proxy/types.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -9,12 +10,37 @@ import (
 // This is what gets returned from the /poll endpoint
 type PendingRequest struct {
 	ID        string          `json:"id"`
+	Endpoint  string          `json:"endpoint"`
 	Request   json.RawMessage `json:"request"` // The raw JSON blob from the client
 	Timestamp time.Time       `json:"timestamp"`
 }
 
 // RespondRequest is sent to the /respond endpoint
 type RespondRequest struct {
-	ID       string          `json:"id"`
-	Response json.RawMessage `json:"response"` // The raw JSON response to send back
+	ID          string          `json:"id"`
+	Response    json.RawMessage `json:"response"`
+	ContentType string          `json:"content_type,omitempty"`
+}
+
+// ProxyResponse is returned to the intercepted LLM client.
+type ProxyResponse struct {
+	Body        []byte
+	ContentType string
+}
+
+func (r RespondRequest) ProxyResponse() (ProxyResponse, error) {
+	contentType := r.ContentType
+	if contentType == "" || contentType == "application/json" {
+		return ProxyResponse{Body: r.Response, ContentType: "application/json"}, nil
+	}
+	if contentType != "text/event-stream" {
+		return ProxyResponse{}, fmt.Errorf("unsupported content type %q", contentType)
+	}
+
+	var body string
+	if err := json.Unmarshal(r.Response, &body); err != nil {
+		return ProxyResponse{}, fmt.Errorf("response must be a JSON string for content type %q: %w", contentType, err)
+	}
+
+	return ProxyResponse{Body: []byte(body), ContentType: contentType}, nil
 }

--- a/examples/02_sequential_eval_with_api.py
+++ b/examples/02_sequential_eval_with_api.py
@@ -14,8 +14,13 @@ Prerequisites:
 Example usage:
 
     uv run -m examples.02_sequential_eval_with_api
+
+    uv run -m examples.02_sequential_eval_with_api \
+        --model openai/gpt-5-mini \
+        --preset-name tbench-opencode
 """
 
+import argparse
 import asyncio
 
 import ares
@@ -25,18 +30,17 @@ from ares.llms import chat_completions_compatible
 from . import utils
 
 
-async def main():
+async def main(*, model: str, preset_name: str):
     # Fail fast if env vars aren't set.
     if not config.CONFIG.chat_completion_api_key:
         raise ValueError("CHAT_COMPLETION_API_KEY is not set")
 
     # Create an LLM client using the ChatCompletionCompatibleLLMClient
-    agent = chat_completions_compatible.ChatCompletionCompatibleLLMClient(model="openai/gpt-5-mini")
+    agent = chat_completions_compatible.ChatCompletionCompatibleLLMClient(model=model)
 
-    # `sbv-mswea` is SWE-bench Verified with mini-swe-agent.
     # `:0` means load only the first task.
     # By default, ares.make will use local Docker containers.
-    async with ares.make("sbv-mswea:0") as env:
+    async with ares.make(f"{preset_name}:0") as env:
         # Reset the environment to get the first timestep
         ts = await env.reset()
         step_count = 0
@@ -61,8 +65,15 @@ async def main():
         print(f"\n{'=' * 80}")
         print(f"Episode completed after {step_count} steps")
         print(f"Total reward: {total_reward}")
+        artifact_dir = getattr(env, "artifact_dir", None)
+        if artifact_dir is not None:
+            print(f"Artifacts: {artifact_dir}")
         print(f"{'=' * 80}")
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="openai/gpt-5-mini")
+    parser.add_argument("--preset-name", default="sbv-mswea")
+    args = parser.parse_args()
+    asyncio.run(main(model=args.model, preset_name=args.preset_name))

--- a/integration_tests/opencode_agent_test.py
+++ b/integration_tests/opencode_agent_test.py
@@ -1,0 +1,87 @@
+"""End-to-end OpenCode agent smoke test."""
+
+import dataclasses
+import os
+import pathlib
+
+import pytest
+
+from ares.code_agents import opencode_agent
+from ares.containers import docker
+from ares.llms import request
+from ares.llms import response
+
+
+@dataclasses.dataclass
+class _SmokeTestLLMClient:
+    calls: int = 0
+    title_calls: int = 0
+
+    async def __call__(self, request: request.LLMRequest) -> response.LLMResponse:
+        self.calls += 1
+        has_tool_result = any(message.get("role") == "tool" for message in request.messages)
+        if has_tool_result:
+            return response.LLMResponse(
+                data=[response.TextData(content="The requested file has been created.")],
+                cost=0.0,
+                usage=response.Usage(prompt_tokens=10, generated_tokens=5),
+            )
+
+        tool_names = {tool["name"] for tool in request.tools or []}
+        if not tool_names:
+            self.title_calls += 1
+            return response.LLMResponse(
+                data=[response.TextData(content="Create OpenCode smoke-test file")],
+                cost=0.0,
+                usage=response.Usage(prompt_tokens=10, generated_tokens=5),
+            )
+        if "write" not in tool_names:
+            raise AssertionError(f"OpenCode did not expose its write tool: {sorted(tool_names)}")
+        return response.LLMResponse(
+            data=[response.TextData(content="")],
+            cost=0.0,
+            usage=response.Usage(prompt_tokens=10, generated_tokens=5),
+            tool_calls=[
+                response.ToolCallData(
+                    call_id="call_write_smoke_test",
+                    name="write",
+                    arguments=('{"filePath":"/tmp/ares-opencode-smoke.txt","content":"hello from opencode\\n"}'),
+                )
+            ],
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get("RUN_OPENCODE_INTEGRATION") != "1",
+    reason="Set RUN_OPENCODE_INTEGRATION=1 to install and run OpenCode in Docker.",
+)
+@pytest.mark.asyncio
+async def test_opencode_runs_through_ares_proxy(tmp_path: pathlib.Path) -> None:
+    container = docker.DockerContainer.from_image(image="ubuntu:22.04")
+    await container.start()
+    try:
+        llm_client = _SmokeTestLLMClient()
+        agent = opencode_agent.OpenCodeAgent(container=container, llm_client=llm_client)
+
+        await agent.run("Create /tmp/ares-opencode-smoke.txt containing exactly 'hello from opencode'.")
+
+        result = await container.exec_run("cat /tmp/ares-opencode-smoke.txt")
+        assert result.exit_code == 0
+        assert result.output.strip() == "hello from opencode"
+        assert llm_client.calls >= 2
+        assert llm_client.title_calls == 0
+
+        mediated_log = await container.exec_run("cat /logs/agent/mediated.jsonl")
+        assert mediated_log.exit_code == 0
+        assert '"event":"request"' in mediated_log.output
+        assert '"event":"response"' in mediated_log.output
+        opencode_log = await container.exec_run("cat /logs/agent/opencode.jsonl")
+        assert opencode_log.exit_code == 0
+        assert opencode_log.output.strip()
+
+        artifact_dir = tmp_path / "artifacts"
+        await container.download_dir("/logs", artifact_dir)
+        assert (artifact_dir / "agent" / "opencode.jsonl").is_file()
+        assert (artifact_dir / "agent" / "mediated.jsonl").is_file()
+    finally:
+        await container.stop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/ares"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"ares-proxy" = "ares/ares-proxy"
+
 [project]
 name = "martian-ares"
 version = "0.1.0"

--- a/src/ares/code_agents/opencode_agent.py
+++ b/src/ares/code_agents/opencode_agent.py
@@ -1,0 +1,521 @@
+"""OpenCode agent running inside an ARES container."""
+
+import asyncio
+import contextlib
+import dataclasses
+import json
+import logging
+import os
+import pathlib
+import shlex
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+from typing import Any, Literal, cast
+import uuid
+
+import openai.types.responses.response_create_params
+
+from ares.containers import containers
+from ares.llms import llm_clients
+from ares.llms import openai_responses_converter
+from ares.llms import request
+from ares.llms import response
+
+_LOGGER = logging.getLogger(__name__)
+
+_PROXY_PORT = 8080
+_PROXY_PATH = "/usr/local/bin/ares-proxy"
+_PROXY_LOG_PATH = "/logs/agent/ares-proxy.log"
+_OPENCODE_LOG_PATH = "/logs/agent/opencode.jsonl"
+_MEDIATED_LOG_PATH = "/logs/agent/mediated.jsonl"
+_OPENCODE_PID_PATH = "/tmp/ares-opencode.pid"
+_OPENCODE_VERSION = "1.14.48"
+_POLL_INTERVAL_SECONDS = 0.25
+_TITLE_SYSTEM_FINGERPRINT = "You are a title generator. You output ONLY a thread title."
+_TITLE_USER_SENTINEL = "Generate a title for this conversation:\n"
+
+_PROXY_BINARY_CACHE: dict[str, pathlib.Path] = {}
+_PROXY_BUILD_LOCK = threading.Lock()
+
+
+@dataclasses.dataclass(frozen=True)
+class PendingProxyRequest:
+    """An LLM request returned by the proxy's poll endpoint."""
+
+    id: str
+    endpoint: Literal["/v1/responses"]
+    request: dict[str, Any]
+
+
+def _parse_pending_request(value: Any) -> PendingProxyRequest:
+    if not isinstance(value, dict):
+        raise ValueError(f"Proxy request must be an object, got {type(value).__name__}")
+
+    request_id = value.get("id")
+    endpoint = value.get("endpoint")
+    request_body = value.get("request")
+    if not isinstance(request_id, str):
+        raise ValueError("Proxy request field 'id' must be a string")
+    if endpoint != "/v1/responses":
+        raise ValueError(f"OpenCode must use /v1/responses, got {endpoint!r}")
+    if not isinstance(request_body, dict):
+        raise ValueError("Proxy request field 'request' must be an object")
+
+    return PendingProxyRequest(id=request_id, endpoint=endpoint, request=request_body)
+
+
+def _is_title_request(llm_request: request.LLMRequest) -> bool:
+    """Identify OpenCode's hidden title request without relying on request order."""
+    user_texts = [message.get("content") for message in llm_request.messages if message.get("role") == "user"]
+    return (
+        _TITLE_SYSTEM_FINGERPRINT in (llm_request.system_prompt or "")
+        and not llm_request.tools
+        and len(user_texts) >= 2
+        and user_texts[0] == _TITLE_USER_SENTINEL
+    )
+
+
+def _to_llm_request(proxy_request: PendingProxyRequest) -> request.LLMRequest:
+    params = dict(proxy_request.request)
+    params.pop("stream", None)
+    return openai_responses_converter.from_external(
+        cast(openai.types.responses.response_create_params.ResponseCreateParamsBase, params),
+        strict=False,
+    )
+
+
+def _sse_event(event: dict[str, Any]) -> str:
+    return f"event: {event['type']}\ndata: {json.dumps(event, separators=(',', ':'))}\n\n"
+
+
+def _to_responses_sse(
+    llm_response: response.LLMResponse,
+    *,
+    model: str,
+) -> str:
+    """Convert one atomic ARES response into a complete Responses API stream."""
+    response_id = f"resp_{uuid.uuid4().hex}"
+    output: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
+    sequence_number = 0
+
+    def add_event(event_type: str, **values: Any) -> None:
+        nonlocal sequence_number
+        events.append({"type": event_type, "sequence_number": sequence_number, **values})
+        sequence_number += 1
+
+    response_base: dict[str, Any] = {
+        "id": response_id,
+        "object": "response",
+        "created_at": int(time.time()),
+        "status": "in_progress",
+        "model": model,
+        "output": [],
+    }
+    add_event("response.created", response=response_base)
+    add_event("response.in_progress", response=response_base)
+
+    text = "".join(part.content for part in llm_response.data)
+    if text or not llm_response.tool_calls:
+        output_index = len(output)
+        item_id = f"msg_{uuid.uuid4().hex}"
+        empty_item = {
+            "id": item_id,
+            "type": "message",
+            "status": "in_progress",
+            "role": "assistant",
+            "content": [],
+        }
+        add_event("response.output_item.added", output_index=output_index, item=empty_item)
+        empty_part = {"type": "output_text", "text": "", "annotations": [], "logprobs": []}
+        add_event(
+            "response.content_part.added",
+            item_id=item_id,
+            output_index=output_index,
+            content_index=0,
+            part=empty_part,
+        )
+        add_event(
+            "response.output_text.delta",
+            item_id=item_id,
+            output_index=output_index,
+            content_index=0,
+            delta=text,
+            logprobs=[],
+        )
+        add_event(
+            "response.output_text.done",
+            item_id=item_id,
+            output_index=output_index,
+            content_index=0,
+            text=text,
+            logprobs=[],
+        )
+        completed_part = {"type": "output_text", "text": text, "annotations": [], "logprobs": []}
+        add_event(
+            "response.content_part.done",
+            item_id=item_id,
+            output_index=output_index,
+            content_index=0,
+            part=completed_part,
+        )
+        completed_item = {**empty_item, "status": "completed", "content": [completed_part]}
+        add_event("response.output_item.done", output_index=output_index, item=completed_item)
+        output.append(completed_item)
+
+    for tool_call in llm_response.tool_calls:
+        output_index = len(output)
+        item_id = f"fc_{uuid.uuid4().hex}"
+        empty_item = {
+            "id": item_id,
+            "type": "function_call",
+            "status": "in_progress",
+            "call_id": tool_call.call_id,
+            "name": tool_call.name,
+            "arguments": "",
+        }
+        add_event("response.output_item.added", output_index=output_index, item=empty_item)
+        add_event(
+            "response.function_call_arguments.delta",
+            item_id=item_id,
+            output_index=output_index,
+            delta=tool_call.arguments,
+        )
+        add_event(
+            "response.function_call_arguments.done",
+            item_id=item_id,
+            output_index=output_index,
+            name=tool_call.name,
+            arguments=tool_call.arguments,
+        )
+        completed_item = {**empty_item, "status": "completed", "arguments": tool_call.arguments}
+        add_event("response.output_item.done", output_index=output_index, item=completed_item)
+        output.append(completed_item)
+
+    usage = {
+        "input_tokens": llm_response.usage.prompt_tokens,
+        "output_tokens": llm_response.usage.generated_tokens,
+        "total_tokens": llm_response.usage.total_tokens,
+    }
+    add_event(
+        "response.completed",
+        response={**response_base, "status": "completed", "output": output, "usage": usage},
+    )
+    return "".join(_sse_event(event) for event in events)
+
+
+def _proxy_source_dir() -> pathlib.Path:
+    package_root = pathlib.Path(__file__).resolve().parents[1]
+    candidates = [package_root / "ares-proxy", package_root.parents[1] / "ares-proxy"]
+    for candidate in candidates:
+        if (candidate / "go.mod").is_file():
+            return candidate
+    raise RuntimeError("Could not locate packaged ares-proxy source")
+
+
+def _build_proxy_sync(source_dir: pathlib.Path, output_path: pathlib.Path, goarch: str) -> None:
+    env = {**os.environ, "GOOS": "linux", "GOARCH": goarch, "CGO_ENABLED": "0"}
+    if go := shutil.which("go"):
+        command = [go, "build", "-o", str(output_path), "."]
+        result = subprocess.run(command, cwd=source_dir, env=env, capture_output=True, text=True)
+    elif docker := shutil.which("docker"):
+        command = [
+            docker,
+            "run",
+            "--rm",
+            "-e",
+            "GOOS=linux",
+            "-e",
+            f"GOARCH={goarch}",
+            "-e",
+            "CGO_ENABLED=0",
+            "-v",
+            f"{source_dir}:/src:ro",
+            "-v",
+            f"{output_path.parent}:/out",
+            "-w",
+            "/src",
+            "golang:1.24-alpine",
+            "go",
+            "build",
+            "-o",
+            f"/out/{output_path.name}",
+            ".",
+        ]
+        result = subprocess.run(command, capture_output=True, text=True)
+    else:
+        raise RuntimeError("Building ares-proxy requires either Go or Docker on the ARES client")
+
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to build ares-proxy: {result.stderr}")
+
+
+def _get_proxy_binary_sync(goarch: str) -> pathlib.Path:
+    with _PROXY_BUILD_LOCK:
+        if goarch in _PROXY_BINARY_CACHE:
+            return _PROXY_BINARY_CACHE[goarch]
+
+        output_path = pathlib.Path(tempfile.mkdtemp(prefix="ares-proxy-")) / "ares-proxy"
+        _build_proxy_sync(_proxy_source_dir(), output_path, goarch)
+        _PROXY_BINARY_CACHE[goarch] = output_path
+        return output_path
+
+
+async def _get_proxy_binary(goarch: str) -> pathlib.Path:
+    return await asyncio.to_thread(_get_proxy_binary_sync, goarch)
+
+
+@dataclasses.dataclass(kw_only=True)
+class OpenCodeAgent:
+    """Install and run OpenCode in a sandbox through ares-proxy."""
+
+    container: containers.Container
+    llm_client: llm_clients.LLMClient
+    opencode_version: str = _OPENCODE_VERSION
+    proxy_timeout_minutes: int = 15
+    poll_interval_seconds: float = _POLL_INTERVAL_SECONDS
+
+    def __post_init__(self) -> None:
+        self._proxy_pid: int | None = None
+        self._opencode_task: asyncio.Task[None] | None = None
+        self._trajectory: list[dict[str, Any]] = []
+
+    async def run(self, task: str) -> None:
+        try:
+            await self._install_proxy()
+            await self._install_opencode()
+            await self._start_proxy()
+            await self._configure_opencode()
+            self._opencode_task = asyncio.create_task(self._run_opencode(task))
+            await self._bridge_requests()
+        finally:
+            try:
+                await self._persist_trajectory()
+            except Exception:
+                _LOGGER.exception("[%d] Failed to persist OpenCode trajectory", id(self))
+            finally:
+                await self._cleanup()
+
+    async def _install_proxy(self) -> None:
+        result = await self.container.exec_run("uname -m")
+        if result.exit_code != 0:
+            raise RuntimeError(f"Failed to determine sandbox architecture: {result.output}")
+        architecture = result.output.strip()
+        goarch = {"x86_64": "amd64", "aarch64": "arm64", "arm64": "arm64"}.get(architecture)
+        if goarch is None:
+            raise RuntimeError(f"Unsupported sandbox architecture: {architecture}")
+
+        proxy_binary = await _get_proxy_binary(goarch)
+        await self.container.upload_file(proxy_binary, _PROXY_PATH)
+        result = await self.container.exec_run(f"chmod +x {_PROXY_PATH}")
+        if result.exit_code != 0:
+            raise RuntimeError(f"Failed to install ares-proxy: {result.output}")
+
+    async def _install_opencode(self) -> None:
+        install_command = " && ".join(
+            [
+                "if ! command -v curl >/dev/null; then "
+                "if command -v apt-get >/dev/null; then apt-get update && apt-get install -y curl ca-certificates; "
+                "elif command -v apk >/dev/null; then apk add --no-cache curl ca-certificates; "
+                "else echo 'curl is required' >&2; exit 1; fi; fi",
+                'if [ ! -s "$HOME/.nvm/nvm.sh" ]; then '
+                "curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash; fi",
+                '. "$HOME/.nvm/nvm.sh"',
+                "nvm install 22",
+                f"npm install -g opencode-ai@{shlex.quote(self.opencode_version)}",
+            ]
+        )
+        result = await self.container.exec_run(install_command, timeout_s=600)
+        if result.exit_code != 0:
+            raise RuntimeError(f"Failed to install OpenCode: {result.output}")
+
+    async def _start_proxy(self) -> None:
+        result = await self.container.exec_run("mkdir -p /logs/agent")
+        if result.exit_code != 0:
+            raise RuntimeError(f"Failed to create agent log directory: {result.output}")
+        command = (
+            f"nohup env PORT={_PROXY_PORT} TIMEOUT_MINUTES={self.proxy_timeout_minutes} "
+            f"{_PROXY_PATH} > {_PROXY_LOG_PATH} 2>&1 & echo $!"
+        )
+        result = await self.container.exec_run(command)
+        if result.exit_code != 0:
+            raise RuntimeError(f"Failed to start ares-proxy: {result.output}")
+        try:
+            self._proxy_pid = int(result.output.strip().splitlines()[-1])
+        except (IndexError, ValueError) as error:
+            raise RuntimeError(f"Failed to parse ares-proxy PID: {result.output}") from error
+
+        result = await self.container.exec_run(
+            f"for _ in $(seq 1 50); do "
+            f"curl -fsS http://localhost:{_PROXY_PORT}/poll >/dev/null && exit 0; "
+            "sleep 0.1; done; "
+            f"cat {_PROXY_LOG_PATH}; exit 1"
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"ares-proxy failed to start: {result.output}")
+
+    async def _configure_opencode(self) -> None:
+        config = {
+            "$schema": "https://opencode.ai/config.json",
+            "agent": {"title": {"disable": True}},
+            "provider": {
+                "ares": {
+                    "name": "ARES",
+                    "npm": "@ai-sdk/openai",
+                    "env": [],
+                    "options": {
+                        "apiKey": "unused",
+                        "baseURL": f"http://localhost:{_PROXY_PORT}/v1",
+                    },
+                    "models": {
+                        "ares": {
+                            "name": "ARES-mediated model",
+                            "limit": {"context": 1_000_000, "output": 128_000},
+                        }
+                    },
+                }
+            },
+        }
+        config_json = shlex.quote(json.dumps(config, separators=(",", ":")))
+        result = await self.container.exec_run(
+            f'mkdir -p "$HOME/.config/opencode" && printf %s {config_json} > "$HOME/.config/opencode/opencode.json"'
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"Failed to configure OpenCode: {result.output}")
+
+    async def _run_opencode(self, task: str) -> None:
+        inner_command = (
+            '. "$HOME/.nvm/nvm.sh" && '
+            f"echo $$ > {_OPENCODE_PID_PATH} && "
+            "exec opencode --model=ares/ares run --format=json --thinking "
+            f"--dangerously-skip-permissions -- {shlex.quote(task)}"
+        )
+        result = await self.container.exec_run(
+            f"bash -lc {shlex.quote(inner_command)} > {_OPENCODE_LOG_PATH} 2>&1",
+            env={"OPENCODE_FAKE_VCS": "git"},
+        )
+        if result.exit_code != 0:
+            log_result = await self.container.exec_run(f"tail -c 10000 {_OPENCODE_LOG_PATH}")
+            raise RuntimeError(f"OpenCode exited with code {result.exit_code}: {log_result.output}")
+
+    async def _bridge_requests(self) -> None:
+        assert self._opencode_task is not None
+        while not self._opencode_task.done():
+            pending_requests = await self._poll_proxy()
+            await asyncio.gather(*(self._process_request(value) for value in pending_requests))
+
+            if not pending_requests:
+                await asyncio.sleep(self.poll_interval_seconds)
+
+        await self._opencode_task
+
+    async def _process_request(self, value: Any) -> None:
+        proxy_request = _parse_pending_request(value)
+        llm_request = _to_llm_request(proxy_request)
+        if _is_title_request(llm_request):
+            self._record_trajectory(
+                "request",
+                request_id=proxy_request.id,
+                endpoint=proxy_request.endpoint,
+                filtered="opencode_title",
+                raw_request=proxy_request.request,
+                llm_request=dataclasses.asdict(llm_request),
+            )
+            title_response = response.LLMResponse(
+                data=[response.TextData(content="ARES evaluation")],
+                cost=0.0,
+                usage=response.Usage(prompt_tokens=0, generated_tokens=0),
+            )
+            self._record_trajectory(
+                "response",
+                request_id=proxy_request.id,
+                filtered="opencode_title",
+                response=dataclasses.asdict(title_response),
+            )
+            model = proxy_request.request.get("model")
+            stream = _to_responses_sse(title_response, model=model if isinstance(model, str) else "ares")
+            await self._respond_to_proxy(proxy_request.id, stream)
+            return
+
+        self._record_trajectory(
+            "request",
+            request_id=proxy_request.id,
+            endpoint=proxy_request.endpoint,
+            raw_request=proxy_request.request,
+            llm_request=dataclasses.asdict(llm_request),
+        )
+        llm_response = await self.llm_client(llm_request)
+        self._record_trajectory(
+            "response",
+            request_id=proxy_request.id,
+            response=dataclasses.asdict(llm_response),
+        )
+        model = proxy_request.request.get("model")
+        stream = _to_responses_sse(llm_response, model=model if isinstance(model, str) else "ares")
+        await self._respond_to_proxy(proxy_request.id, stream)
+
+    def _record_trajectory(self, event: str, **values: Any) -> None:
+        self._trajectory.append({"event": event, "timestamp": time.time(), **values})
+
+    async def _persist_trajectory(self) -> None:
+        if not self._trajectory:
+            return
+
+        with tempfile.TemporaryDirectory(prefix="ares-opencode-trajectory-") as temp_dir:
+            local_path = pathlib.Path(temp_dir) / "mediated.jsonl"
+            local_path.write_text(
+                "".join(json.dumps(record, default=str, separators=(",", ":")) + "\n" for record in self._trajectory)
+            )
+            await self.container.upload_file(local_path, _MEDIATED_LOG_PATH)
+
+    async def _poll_proxy(self) -> list[Any]:
+        result = await self.container.exec_run(
+            f"curl -fsS http://localhost:{_PROXY_PORT}/poll",
+            timeout_s=10,
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"Failed to poll ares-proxy: {result.output}")
+        try:
+            value = json.loads(result.output)
+        except json.JSONDecodeError as error:
+            raise RuntimeError(f"ares-proxy returned invalid poll JSON: {result.output}") from error
+        if not isinstance(value, list):
+            raise RuntimeError(f"ares-proxy poll response must be a list, got {type(value).__name__}")
+        return value
+
+    async def _respond_to_proxy(self, request_id: str, stream: str) -> None:
+        payload = shlex.quote(
+            json.dumps(
+                {
+                    "id": request_id,
+                    "response": stream,
+                    "content_type": "text/event-stream",
+                },
+                separators=(",", ":"),
+            )
+        )
+        result = await self.container.exec_run(
+            f"curl -fsS -X POST http://localhost:{_PROXY_PORT}/respond "
+            f"-H 'Content-Type: application/json' --data-binary {payload}",
+            timeout_s=10,
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"Failed to respond through ares-proxy: {result.output}")
+
+    async def _cleanup(self) -> None:
+        await self.container.exec_run(
+            f"if [ -f {_OPENCODE_PID_PATH} ]; then kill $(cat {_OPENCODE_PID_PATH}) 2>/dev/null || true; fi"
+        )
+        if self._proxy_pid is not None:
+            await self.container.exec_run(f"kill {self._proxy_pid} 2>/dev/null || true")
+            self._proxy_pid = None
+
+        if self._opencode_task is not None:
+            if not self._opencode_task.done():
+                self._opencode_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._opencode_task
+        self._opencode_task = None

--- a/src/ares/code_agents/opencode_agent_test.py
+++ b/src/ares/code_agents/opencode_agent_test.py
@@ -1,0 +1,266 @@
+"""Tests for the in-sandbox OpenCode agent."""
+
+import asyncio
+import concurrent.futures
+import dataclasses
+import json
+import pathlib
+import shlex
+
+import pytest
+
+from ares.code_agents import opencode_agent
+from ares.containers import containers
+from ares.llms import request
+from ares.llms import response
+from ares.testing import mock_container
+
+
+def _parse_sse(stream: str) -> list[dict]:
+    events = []
+    for block in stream.strip().split("\n\n"):
+        lines = block.splitlines()
+        assert lines[0].startswith("event: ")
+        assert lines[1].startswith("data: ")
+        events.append(json.loads(lines[1].removeprefix("data: ")))
+    return events
+
+
+def test_to_responses_sse_serializes_text_and_tool_calls() -> None:
+    llm_response = response.LLMResponse(
+        data=[response.TextData(content="Checking the repository.")],
+        cost=0.0,
+        usage=response.Usage(prompt_tokens=12, generated_tokens=7),
+        tool_calls=[
+            response.ToolCallData(
+                call_id="call_123",
+                name="bash",
+                arguments='{"command":"pwd"}',
+            )
+        ],
+    )
+
+    events = _parse_sse(opencode_agent._to_responses_sse(llm_response, model="ares"))
+
+    event_types = [event["type"] for event in events]
+    assert event_types[0:2] == ["response.created", "response.in_progress"]
+    assert "response.output_text.delta" in event_types
+    assert "response.function_call_arguments.delta" in event_types
+    assert event_types[-1] == "response.completed"
+
+    function_call = next(
+        event["item"]
+        for event in events
+        if event["type"] == "response.output_item.done" and event["item"]["type"] == "function_call"
+    )
+    assert function_call["call_id"] == "call_123"
+    assert function_call["name"] == "bash"
+    assert function_call["arguments"] == '{"command":"pwd"}'
+    assert events[-1]["response"]["usage"] == {
+        "input_tokens": 12,
+        "output_tokens": 7,
+        "total_tokens": 19,
+    }
+
+
+def _title_request() -> dict:
+    return {
+        "id": "title-request",
+        "endpoint": "/v1/responses",
+        "request": {
+            "model": "ares",
+            "stream": True,
+            "store": False,
+            "input": [
+                {
+                    "role": "developer",
+                    "content": f"{opencode_agent._TITLE_SYSTEM_FINGERPRINT}\n\n<task>Generate a brief title.</task>",
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": opencode_agent._TITLE_USER_SENTINEL}],
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Fix the bug"}],
+                },
+            ],
+        },
+    }
+
+
+def test_title_request_detection_is_content_based() -> None:
+    assert opencode_agent._is_title_request(
+        opencode_agent._to_llm_request(opencode_agent._parse_pending_request(_title_request()))
+    )
+
+    first_real_request = _title_request()
+    first_real_request["request"]["input"][0]["content"] = "You are a coding agent."
+    assert not opencode_agent._is_title_request(
+        opencode_agent._to_llm_request(opencode_agent._parse_pending_request(first_real_request))
+    )
+
+
+@pytest.mark.asyncio
+async def test_title_request_is_answered_without_llm_client() -> None:
+    container = _SimulatedOpenCodeContainer()
+    llm_client = _ToolCallingLLMClient()
+    agent = opencode_agent.OpenCodeAgent(container=container, llm_client=llm_client)
+
+    await agent._process_request(_title_request())
+
+    assert llm_client.requests == []
+    assert container.response_payload is not None
+    assert "ARES evaluation" in container.response_payload["response"]
+    assert agent._trajectory[0]["filtered"] == "opencode_title"
+
+
+def test_proxy_binary_build_is_thread_safe(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    architecture = "test-thread-architecture"
+    opencode_agent._PROXY_BINARY_CACHE.pop(architecture, None)
+    build_count = 0
+
+    def build_proxy(source_dir: pathlib.Path, output_path: pathlib.Path, goarch: str) -> None:
+        nonlocal build_count
+        assert source_dir == tmp_path
+        assert goarch == architecture
+        build_count += 1
+        output_path.write_bytes(b"proxy")
+
+    monkeypatch.setattr(opencode_agent, "_proxy_source_dir", lambda: tmp_path)
+    monkeypatch.setattr(opencode_agent, "_build_proxy_sync", build_proxy)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        binaries = list(executor.map(opencode_agent._get_proxy_binary_sync, [architecture] * 4))
+
+    assert len(set(binaries)) == 1
+    assert build_count == 1
+    opencode_agent._PROXY_BINARY_CACHE.pop(architecture, None)
+
+
+@dataclasses.dataclass
+class _SimulatedOpenCodeContainer(mock_container.MockContainer):
+    opencode_started: asyncio.Event = dataclasses.field(default_factory=asyncio.Event)
+    opencode_finished: asyncio.Event = dataclasses.field(default_factory=asyncio.Event)
+    request_polled: bool = False
+    response_payload: dict | None = None
+
+    async def exec_run(
+        self,
+        command: str,
+        *,
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_s: float | None = None,
+    ) -> containers.ExecResult:
+        del workdir, env, timeout_s
+        self.exec_commands.append(command)
+
+        if command == "uname -m":
+            return containers.ExecResult(output="x86_64\n", exit_code=0)
+        if command.startswith("nohup env PORT="):
+            return containers.ExecResult(output="123\n", exit_code=0)
+        if command.startswith("for _ in $(seq 1 50)"):
+            return containers.ExecResult(output="", exit_code=0)
+        if "exec opencode" in command:
+            self.opencode_started.set()
+            await self.opencode_finished.wait()
+            return containers.ExecResult(output="", exit_code=0)
+        if command == "curl -fsS http://localhost:8080/poll":
+            if not self.opencode_started.is_set() or self.request_polled:
+                return containers.ExecResult(output="[]\n", exit_code=0)
+            self.request_polled = True
+            pending = [
+                {
+                    "id": "proxy-request-1",
+                    "endpoint": "/v1/responses",
+                    "timestamp": "2026-08-03T00:00:00Z",
+                    "request": {
+                        "model": "ares",
+                        "stream": True,
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [{"type": "input_text", "text": "Create hello.txt"}],
+                            }
+                        ],
+                        "tools": [
+                            {
+                                "type": "function",
+                                "name": "write",
+                                "description": "Write a file",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {
+                                        "filePath": {"type": "string"},
+                                        "content": {"type": "string"},
+                                    },
+                                },
+                            }
+                        ],
+                    },
+                }
+            ]
+            return containers.ExecResult(output=json.dumps(pending), exit_code=0)
+        if command.startswith("curl -fsS -X POST http://localhost:8080/respond"):
+            parts = shlex.split(command)
+            self.response_payload = json.loads(parts[parts.index("--data-binary") + 1])
+            self.opencode_finished.set()
+            return containers.ExecResult(output='{"status":"ok"}', exit_code=0)
+
+        return containers.ExecResult(output="", exit_code=0)
+
+
+@dataclasses.dataclass
+class _ToolCallingLLMClient:
+    requests: list[request.LLMRequest] = dataclasses.field(default_factory=list)
+
+    async def __call__(self, request: request.LLMRequest) -> response.LLMResponse:
+        self.requests.append(request)
+        return response.LLMResponse(
+            data=[response.TextData(content="")],
+            cost=0.0,
+            usage=response.Usage(prompt_tokens=10, generated_tokens=5),
+            tool_calls=[
+                response.ToolCallData(
+                    call_id="call_write",
+                    name="write",
+                    arguments='{"filePath":"/workspace/hello.txt","content":"hello"}',
+                )
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_opencode_agent_runs_proxy_bridge(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    proxy_binary = tmp_path / "ares-proxy"
+    proxy_binary.write_bytes(b"binary")
+
+    async def get_proxy_binary(goarch: str) -> pathlib.Path:
+        assert goarch == "amd64"
+        return proxy_binary
+
+    monkeypatch.setattr(opencode_agent, "_get_proxy_binary", get_proxy_binary)
+    container = _SimulatedOpenCodeContainer()
+    llm_client = _ToolCallingLLMClient()
+    agent = opencode_agent.OpenCodeAgent(
+        container=container,
+        llm_client=llm_client,
+        poll_interval_seconds=0.001,
+    )
+
+    await asyncio.wait_for(agent.run("Create hello.txt"), timeout=2)
+
+    assert container.uploaded_files[0] == (proxy_binary, "/usr/local/bin/ares-proxy")
+    assert container.uploaded_files[-1][1] == "/logs/agent/mediated.jsonl"
+    assert any("npm install -g opencode-ai@1.14.48" in command for command in container.exec_commands)
+    assert any('"npm":"@ai-sdk/openai"' in command for command in container.exec_commands)
+    assert any('"agent":{"title":{"disable":true}}' in command for command in container.exec_commands)
+    assert any("opencode --model=ares/ares run" in command for command in container.exec_commands)
+    assert any("> /logs/agent/opencode.jsonl 2>&1" in command for command in container.exec_commands)
+    assert len(llm_client.requests) == 1
+    assert llm_client.requests[0].messages == [{"role": "user", "content": "Create hello.txt"}]
+
+    assert container.response_payload is not None
+    assert container.response_payload["id"] == "proxy-request-1"
+    assert container.response_payload["content_type"] == "text/event-stream"

--- a/src/ares/containers/containers.py
+++ b/src/ares/containers/containers.py
@@ -86,13 +86,14 @@ class Container(Protocol):
         """Upload a full directory to the container."""
         local_path_uploads = []
         remote_path_uploads = []
+        remote_root = pathlib.PurePosixPath(remote_path)
 
         for file_path in local_path.rglob("*"):
             if file_path.is_file():
                 relative_path = file_path.relative_to(local_path)
-                destination_path = str(remote_path / relative_path)
+                destination_path = str(remote_root / relative_path)
 
-                local_path_uploads.append(str(file_path))
+                local_path_uploads.append(file_path)
                 remote_path_uploads.append(destination_path)
 
         await self.upload_files(local_path_uploads, remote_path_uploads)
@@ -118,7 +119,7 @@ class Container(Protocol):
             local_file_path.parent.mkdir(parents=True, exist_ok=True)
 
             remote_path_downloads.append(file_path)
-            local_path_downloads.append(str(local_file_path))
+            local_path_downloads.append(local_file_path)
 
         if remote_path_downloads:
             await self.download_files(remote_path_downloads, local_path_downloads)

--- a/src/ares/environments/base.py
+++ b/src/ares/environments/base.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import os
 import pathlib
+import re
 import time
 from types import TracebackType
 from typing import Literal, NamedTuple, Protocol, Self
@@ -186,7 +187,11 @@ async def create_container(
     else:
         raise ValueError("Must specify one of image_name or dockerfile_path")
 
-    container_name = f"ares.{container_prefix}.{image_name_short}.{timestamp}.{unique_id}"
+    container_name = re.sub(
+        r"[^a-zA-Z0-9_.-]",
+        "-",
+        f"ares.{container_prefix}.{image_name_short}.{timestamp}.{unique_id}",
+    )
     container = create_fn(name=container_name, resources=resources)
 
     return container

--- a/src/ares/environments/base_test.py
+++ b/src/ares/environments/base_test.py
@@ -1,0 +1,52 @@
+"""Tests for environment utilities."""
+
+import pathlib
+
+import pytest
+
+from ares.containers import containers
+from ares.environments import base
+from ares.testing import mock_container
+
+
+class _CapturingContainerFactory:
+    name: str | None = None
+
+    @classmethod
+    def from_image(
+        cls,
+        *,
+        image: str,
+        name: str | None = None,
+        resources: containers.Resources | None = None,
+        default_workdir: str | None = None,
+    ) -> mock_container.MockContainer:
+        del image, resources, default_workdir
+        cls.name = name
+        return mock_container.MockContainer()
+
+    @classmethod
+    def from_dockerfile(
+        cls,
+        *,
+        dockerfile_path: pathlib.Path | str,
+        name: str | None = None,
+        resources: containers.Resources | None = None,
+        default_workdir: str | None = None,
+    ) -> mock_container.MockContainer:
+        del dockerfile_path, resources, default_workdir
+        cls.name = name
+        return mock_container.MockContainer()
+
+
+@pytest.mark.asyncio
+async def test_create_container_sanitizes_image_tag_in_name() -> None:
+    await base.create_container(
+        container_factory=_CapturingContainerFactory,
+        container_prefix="harbor_env",
+        image_name="alexgshaw/gpt2-codegolf:20251031",
+    )
+
+    assert _CapturingContainerFactory.name is not None
+    assert ":" not in _CapturingContainerFactory.name
+    assert "gpt2-codegolf-20251031" in _CapturingContainerFactory.name

--- a/src/ares/environments/code_env.py
+++ b/src/ares/environments/code_env.py
@@ -13,9 +13,12 @@ import json
 import logging
 import pathlib
 import random
+import re
+import shlex
 import time
 from types import TracebackType
 from typing import Self
+import uuid
 
 from harbor.models import registry as harbor_registry
 from harbor.models.task import task as harbor_task
@@ -68,6 +71,7 @@ class CodeEnvironment(base.Environment[response.LLMResponse, request.LLMRequest 
         step_limit: int = DEFAULT_STEP_LIMIT,
         prefix: str = "harbor_env",
         tracker: stat_tracker.StatTracker | None = None,
+        artifact_root: pathlib.Path | str | None = None,
     ):
         self._tasks = tasks
         self._container_factory = container_factory
@@ -75,6 +79,7 @@ class CodeEnvironment(base.Environment[response.LLMResponse, request.LLMRequest 
         self._step_limit = step_limit
         self._prefix = prefix
         self._tracker = tracker if tracker is not None else stat_tracker.NullStatTracker()
+        self._artifact_root = pathlib.Path(artifact_root) if artifact_root is not None else None
 
         # We set the LLM client to a queue mediated client so that
         # we can return LLM requests in the reset and step methods.
@@ -89,6 +94,8 @@ class CodeEnvironment(base.Environment[response.LLMResponse, request.LLMRequest 
         self._code_agent_task: asyncio.Task[None] | None = None
         self._step_count = 0
         self._requires_reset = False
+        self._episode_artifact_dir: pathlib.Path | None = None
+        self._artifacts_persisted = False
 
         # Register for cleanup on exit.
         _ENVIRONMENT_JANITOR.register_for_cleanup(self)
@@ -102,11 +109,7 @@ class CodeEnvironment(base.Environment[response.LLMResponse, request.LLMRequest 
         self._step_count = 0
         self._requires_reset = False
 
-        if self._container is not None:
-            _LOGGER.debug("[%d] Stopping container on reset.", id(self))
-            # Stop the container to free resources.
-            await self._container.stop()
-            self._container = None
+        await self._stop_container()
 
         await self._reset_task()
         await self._start_container()
@@ -184,8 +187,11 @@ class CodeEnvironment(base.Environment[response.LLMResponse, request.LLMRequest 
             assert self._container is not None
             assert self._current_task is not None
             _LOGGER.debug("[%d] Running tests and evaluating.", id(self))
-            with self._tracker.timeit(f"{self._prefix}/run_tests_and_evaluate"):
-                reward = await self._compute_reward()
+            try:
+                with self._tracker.timeit(f"{self._prefix}/run_tests_and_evaluate"):
+                    reward = await self._compute_reward()
+            finally:
+                await self._persist_artifacts()
             _LOGGER.debug("[%d] Tests and evaluation completed. Reward: %f.", id(self), reward)
 
             # Cancel the queue get task.
@@ -211,10 +217,15 @@ class CodeEnvironment(base.Environment[response.LLMResponse, request.LLMRequest 
                 await self._code_agent_task
             self._code_agent_task = None
 
-        if self._container is not None:
-            _LOGGER.debug("[%d] Stopping container on exit.", id(self))
-            await self._container.stop()
-            self._container = None
+        await self._stop_container()
+
+    async def _stop_container(self) -> None:
+        if self._container is None:
+            return
+        _LOGGER.debug("[%d] Persisting artifacts and stopping container.", id(self))
+        await self._persist_artifacts()
+        await self._container.stop()
+        self._container = None
 
     async def __aenter__(self) -> Self:
         self._is_active = True
@@ -238,6 +249,13 @@ class CodeEnvironment(base.Environment[response.LLMResponse, request.LLMRequest 
     async def _reset_task(self) -> None:
         """Randomly select a task from the task list."""
         self._current_task = random.choice(self._tasks)
+        self._artifacts_persisted = False
+        if self._artifact_root is not None:
+            task_name = re.sub(r"[^a-zA-Z0-9_.-]", "-", self._current_task.name)
+            episode_id = f"{int(time.time())}-{str(uuid.uuid4())[:8]}"
+            self._episode_artifact_dir = self._artifact_root / f"{task_name}-{episode_id}"
+        else:
+            self._episode_artifact_dir = None
         _LOGGER.debug("[%d] Selected task %s.", id(self), self._current_task.name)
 
     async def _start_container(self) -> None:
@@ -261,6 +279,9 @@ class CodeEnvironment(base.Environment[response.LLMResponse, request.LLMRequest 
                 ),
             )
             await self._container.start()
+            log_dirs_result = await self._container.exec_run("mkdir -p /logs/agent /logs/verifier /logs/artifacts")
+            if log_dirs_result.exit_code != 0:
+                raise RuntimeError(f"Failed to create container log directories: {log_dirs_result.output}")
         _LOGGER.debug("[%d] Container setup complete.", id(self))
 
     async def _start_code_agent(self) -> None:
@@ -296,9 +317,10 @@ class CodeEnvironment(base.Environment[response.LLMResponse, request.LLMRequest 
         test_path = str(
             pathlib.Path("/tests") / self._current_task.paths.test_path.relative_to(self._current_task.paths.tests_dir)
         )
-        # TODO: Log the output of the test execution somewhere that makes sense
-        test_result = await self._container.exec_run(command=f"bash {test_path}")
-        _LOGGER.debug("[%d] Test result: %s.", id(self), test_result.output)
+        test_result = await self._container.exec_run(
+            command=f"bash {shlex.quote(test_path)} > /logs/verifier/test-stdout.txt 2>&1"
+        )
+        _LOGGER.debug("[%d] Test exited with code %d.", id(self), test_result.exit_code)
 
         # Try to read reward from both
         for reward_path in [
@@ -316,6 +338,24 @@ class CodeEnvironment(base.Environment[response.LLMResponse, request.LLMRequest 
                 pass
 
         raise ValueError(f"[{id(self)}] No reward found for task {self._current_task.name}")
+
+    @property
+    def artifact_dir(self) -> pathlib.Path | None:
+        """Host directory containing the current episode's persisted logs."""
+        return self._episode_artifact_dir
+
+    async def _persist_artifacts(self) -> None:
+        if self._container is None or self._episode_artifact_dir is None or self._artifacts_persisted:
+            return
+
+        try:
+            await self._container.download_dir("/logs", self._episode_artifact_dir)
+        except Exception:
+            _LOGGER.exception("[%d] Failed to persist artifacts to %s", id(self), self._episode_artifact_dir)
+            return
+
+        self._artifacts_persisted = True
+        _LOGGER.info("[%d] Persisted episode artifacts to %s", id(self), self._episode_artifact_dir)
 
     async def _parse_reward_file(self, remote_path: pathlib.Path | str) -> float | None:
         """Helper to parse a reward from a text or json file in the container."""

--- a/src/ares/environments/code_env_test.py
+++ b/src/ares/environments/code_env_test.py
@@ -1,0 +1,72 @@
+"""Tests for the code environment."""
+
+import pathlib
+import types
+from typing import Any, cast
+
+import pytest
+
+from ares.containers import containers
+from ares.environments import code_env
+from ares.testing import mock_container
+
+
+@pytest.mark.asyncio
+async def test_persist_artifacts_downloads_harbor_log_tree(tmp_path: pathlib.Path) -> None:
+    def exec_handler(command: str) -> containers.ExecResult:
+        if command == "find /logs -type f":
+            return containers.ExecResult(
+                output=("/logs/agent/opencode.jsonl\n/logs/agent/mediated.jsonl\n/logs/verifier/test-stdout.txt\n"),
+                exit_code=0,
+            )
+        return containers.ExecResult(output="", exit_code=0)
+
+    container = mock_container.MockContainer(exec_handler=exec_handler)
+    env = code_env.CodeEnvironment(tasks=[], artifact_root=tmp_path)
+    env._container = container
+    env._episode_artifact_dir = tmp_path / "episode"
+    try:
+        await env._persist_artifacts()
+
+        assert [remote for remote, _ in container.downloaded_files] == [
+            "/logs/agent/opencode.jsonl",
+            "/logs/agent/mediated.jsonl",
+            "/logs/verifier/test-stdout.txt",
+        ]
+        assert env._artifacts_persisted is True
+        assert (tmp_path / "episode" / "agent").is_dir()
+        assert (tmp_path / "episode" / "verifier").is_dir()
+        assert all(isinstance(local, pathlib.Path) for _, local in container.downloaded_files)
+    finally:
+        code_env._ENVIRONMENT_JANITOR.unregister_for_cleanup(env)
+
+
+@pytest.mark.asyncio
+async def test_compute_reward_persists_verifier_output(tmp_path: pathlib.Path) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    test_path = tests_dir / "test.sh"
+    test_path.write_text("#!/bin/bash\nexit 1\n")
+
+    def exec_handler(command: str) -> containers.ExecResult:
+        if command == "cat /logs/verifier/reward.txt":
+            return containers.ExecResult(output="0\n", exit_code=0)
+        return containers.ExecResult(output="", exit_code=0)
+
+    container = mock_container.MockContainer(exec_handler=exec_handler)
+    env = code_env.CodeEnvironment(tasks=[])
+    env._container = container
+    env._current_task = cast(
+        Any,
+        types.SimpleNamespace(
+            name="test-task",
+            paths=types.SimpleNamespace(tests_dir=tests_dir, test_path=test_path),
+        ),
+    )
+    try:
+        reward = await env._compute_reward()
+
+        assert reward == 0.0
+        assert "bash /tests/test.sh > /logs/verifier/test-stdout.txt 2>&1" in container.exec_commands
+    finally:
+        code_env._ENVIRONMENT_JANITOR.unregister_for_cleanup(env)

--- a/src/ares/llms/__init__.py
+++ b/src/ares/llms/__init__.py
@@ -14,6 +14,7 @@ from ares.llms.request import UserMessage
 # Response types
 from ares.llms.response import LLMResponse
 from ares.llms.response import TextData
+from ares.llms.response import ToolCallData
 from ares.llms.response import Usage
 
 __all__ = [
@@ -24,6 +25,7 @@ __all__ = [
     "LLMResponse",
     "Message",
     "TextData",
+    "ToolCallData",
     "ToolCallMessage",
     "ToolCallResponseMessage",
     "Usage",

--- a/src/ares/llms/chat_completions_compatible.py
+++ b/src/ares/llms/chat_completions_compatible.py
@@ -72,9 +72,24 @@ class ChatCompletionCompatibleLLMClient(llm_clients.LLMClient):
         cost = accounting.get_llm_cost(self.model, resp, cost_mapping=accounting.martian_cost_list())
         cost = float(cost)
 
-        content = resp.choices[0].message.content or ""
+        message = resp.choices[0].message
+        content = message.content or ""
+        tool_calls = [
+            response.ToolCallData(
+                call_id=tool_call.id,
+                name=tool_call.function.name,
+                arguments=tool_call.function.arguments,
+            )
+            for tool_call in (message.tool_calls or [])
+            if tool_call.type == "function"
+        ]
         usage = response.Usage(
             prompt_tokens=resp.usage.prompt_tokens if resp.usage else 0,
             generated_tokens=resp.usage.completion_tokens if resp.usage else 0,
         )
-        return response.LLMResponse(data=[response.TextData(content=content)], cost=cost, usage=usage)
+        return response.LLMResponse(
+            data=[response.TextData(content=content)],
+            cost=cost,
+            usage=usage,
+            tool_calls=tool_calls,
+        )

--- a/src/ares/llms/chat_completions_compatible_test.py
+++ b/src/ares/llms/chat_completions_compatible_test.py
@@ -1,0 +1,62 @@
+"""Tests for the Chat Completions-compatible LLM client."""
+
+import openai.types.chat.chat_completion
+import pytest
+
+from ares.llms import chat_completions_compatible
+
+
+@pytest.mark.asyncio
+async def test_client_preserves_tool_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    completion = openai.types.chat.chat_completion.ChatCompletion.model_validate(
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_123",
+                                "type": "function",
+                                "function": {"name": "bash", "arguments": '{"command":"pwd"}'},
+                            }
+                        ],
+                    },
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14},
+        }
+    )
+
+    async def query(*args, **kwargs):
+        del args, kwargs
+        return completion
+
+    def get_cost(*args, **kwargs):
+        del args, kwargs
+        return 0.0
+
+    monkeypatch.setattr(chat_completions_compatible, "_query_llm_with_retry", query)
+    monkeypatch.setattr(chat_completions_compatible.accounting, "get_llm_cost", get_cost)
+    monkeypatch.setattr(chat_completions_compatible.accounting, "martian_cost_list", lambda: {})
+
+    client = chat_completions_compatible.ChatCompletionCompatibleLLMClient(
+        model="test-model",
+        base_url="http://unused",
+        api_key="unused",
+    )
+    result = await client(
+        chat_completions_compatible.request.LLMRequest(messages=[{"role": "user", "content": "Run pwd"}])
+    )
+
+    assert result.data[0].content == ""
+    assert result.tool_calls[0].call_id == "call_123"
+    assert result.tool_calls[0].name == "bash"
+    assert result.tool_calls[0].arguments == '{"command":"pwd"}'

--- a/src/ares/llms/openai_responses_converter.py
+++ b/src/ares/llms/openai_responses_converter.py
@@ -23,6 +23,27 @@ from ares.llms import request as llm_request
 _LOGGER = logging.getLogger(__name__)
 
 
+def _message_content_from_responses(content: Any, *, strict: bool, role: str) -> str:
+    """Extract text from Responses API message content."""
+    if not isinstance(content, list):
+        return llm_request._extract_string_content(content, strict=strict, context=f"Message content (role={role})")
+
+    text_parts = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") in {"input_text", "output_text", "text"}:
+            text = block.get("text", "")
+            if isinstance(text, str):
+                text_parts.append(text)
+                continue
+
+        msg = f"Unsupported Responses message content block for role={role}: {block}"
+        if strict:
+            raise ValueError(msg)
+        _LOGGER.warning(msg)
+
+    return "".join(text_parts)
+
+
 def _tool_to_responses(tool: llm_request.Tool) -> openai.types.responses.FunctionToolParam:
     """Convert Tool from ARES internal format to OpenAI Responses format.
 
@@ -294,6 +315,7 @@ def from_external(
         "metadata",
         "service_tier",
         "instructions",
+        "store",  # Response persistence is provider-side state and is intentionally ignored.
     }
 
     # Check for unhandled parameters
@@ -307,6 +329,7 @@ def from_external(
     # Convert input items to messages
     input_param = kwargs.get("input", [])
     filtered_messages: list[llm_request.Message] = []
+    system_prompt = kwargs.get("instructions")
 
     if isinstance(input_param, str):
         filtered_messages = [llm_request.UserMessage(role="user", content=input_param)]
@@ -327,6 +350,10 @@ def from_external(
                         )
                     _LOGGER.warning("Tool call (function_call) missing required fields, skipping. Item: %s", item)
                     continue
+
+                previous = filtered_messages[-1] if filtered_messages else None
+                if previous is None or (previous.get("role") != "assistant" and "call_id" not in previous):
+                    filtered_messages.append(llm_request.AssistantMessage(role="assistant", content=""))
 
                 # Create ToolCallMessage
                 filtered_messages.append(
@@ -365,9 +392,14 @@ def from_external(
                         cast(llm_request.Message, {"role": "tool", "content": output_str, "tool_call_id": call_id})
                     )
 
-            # Handle regular messages
-            elif item_type == "message":
+            # EasyInputMessage permits omitting type when role is present.
+            elif item_type == "message" or (item_type is None and "role" in item):
                 role = item.get("role")
+
+                if role in {"system", "developer"}:
+                    content_str = _message_content_from_responses(item.get("content", ""), strict=strict, role=role)
+                    system_prompt = "\n\n".join(part for part in [system_prompt, content_str] if part)
+                    continue
 
                 # Validate role is supported
                 if role not in llm_request._VALID_ROLES:
@@ -376,11 +408,7 @@ def from_external(
                     _LOGGER.warning("Skipping message with unsupported role: %s", role)
                     continue
 
-                # Extract content - use helper to detect unsupported block formats
-                content_param = item.get("content", "")
-                content_str = llm_request._extract_string_content(
-                    content_param, strict=strict, context=f"Message content (role={role})"
-                )
+                content_str = _message_content_from_responses(item.get("content", ""), strict=strict, role=role)
 
                 # Build message dict with required fields
                 message_dict: dict[str, Any] = {"role": role, "content": content_str}
@@ -431,5 +459,5 @@ def from_external(
         tool_choice=resolved_tool_choice,
         metadata=cast(dict[str, Any] | None, kwargs.get("metadata")),
         service_tier=kwargs.get("service_tier"),
-        system_prompt=kwargs.get("instructions"),
+        system_prompt=system_prompt,
     )

--- a/src/ares/llms/openai_responses_converter_test.py
+++ b/src/ares/llms/openai_responses_converter_test.py
@@ -31,7 +31,7 @@ class TestStructuredContentHandling:
             ],
         )
 
-        with pytest.raises(ValueError, match=r"list of blocks.*structured content"):
+        with pytest.raises(ValueError, match="Unsupported Responses message content block"):
             openai_responses_converter.from_external(kwargs, strict=True)
 
     def test_from_responses_with_structured_content_non_strict(self):
@@ -52,10 +52,10 @@ class TestStructuredContentHandling:
             ],
         )
 
-        # Should not raise, but content will be empty
+        # Unsupported blocks are skipped without losing supported text blocks.
         request = openai_responses_converter.from_external(kwargs, strict=False)
         assert len(request.messages) == 1
-        assert request.messages[0].get("content") == ""
+        assert request.messages[0].get("content") == "Hello"
 
 
 class TestLLMRequestResponsesConversion:
@@ -201,19 +201,33 @@ class TestLLMRequestResponsesConversion:
 
         assert list(request.messages) == [{"role": "user", "content": "Hello, world!"}]
 
-    def test_from_responses_list_input(self):
-        """Test parsing Responses with list input."""
-        kwargs: openai.types.responses.response_create_params.ResponseCreateParams = {
-            "model": "gpt-4o",
-            "input": [
-                {"type": "message", "role": "user", "content": "Hello"},
-                {"type": "message", "role": "assistant", "content": "Hi!"},
-            ],
-        }
+    def test_from_responses_opencode_easy_input_messages(self):
+        """Test OpenCode's block content and omitted message type."""
+        kwargs = cast(
+            openai.types.responses.response_create_params.ResponseCreateParams,
+            {
+                "model": "ares",
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "Hello"},
+                            {"type": "input_text", "text": ", world!"},
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Hi!"}],
+                    },
+                ],
+                "stream": True,
+            },
+        )
+
         request = openai_responses_converter.from_external(kwargs)
 
-        assert list(request.messages) == [
-            {"role": "user", "content": "Hello"},
+        assert request.messages == [
+            {"role": "user", "content": "Hello, world!"},
             {"role": "assistant", "content": "Hi!"},
         ]
 
@@ -320,7 +334,8 @@ class TestLLMRequestResponsesConversion:
         )
         request = openai_responses_converter.from_external(kwargs)
 
-        tool_call_msg = request.messages[1]
+        assert request.messages[1] == {"role": "assistant", "content": ""}
+        tool_call_msg = request.messages[2]
         assert "call_id" in tool_call_msg
         assert tool_call_msg["call_id"] == "call_456"  # type: ignore[typeddict-item]
         assert tool_call_msg["name"] == "get_weather"  # type: ignore[typeddict-item]

--- a/src/ares/llms/response.py
+++ b/src/ares/llms/response.py
@@ -24,6 +24,15 @@ class TextData:
 
 
 @dataclasses.dataclass(frozen=True)
+class ToolCallData:
+    """A function call requested by the LLM."""
+
+    call_id: str
+    name: str
+    arguments: str
+
+
+@dataclasses.dataclass(frozen=True)
 class LLMResponse:
     """Response from an LLM call.
 
@@ -31,8 +40,10 @@ class LLMResponse:
         data: List of content blocks (currently only TextData, but extensible to ImageData, etc.)
         cost: Cost of the LLM call in USD.
         usage: Token usage information.
+        tool_calls: Function calls requested by the LLM.
     """
 
     data: list[TextData]
     cost: float
     usage: Usage
+    tool_calls: list[ToolCallData] = dataclasses.field(default_factory=list)

--- a/src/ares/presets.py
+++ b/src/ares/presets.py
@@ -12,6 +12,7 @@ import collections
 import dataclasses
 import functools
 import logging
+import pathlib
 
 from harbor.models import registry as harbor_registry
 from harbor.models.task import task as harbor_task
@@ -19,6 +20,7 @@ from harbor.models.task import task as harbor_task
 from ares import registry
 from ares.code_agents import code_agent_base
 from ares.code_agents import mini_swe_agent
+from ares.code_agents import opencode_agent
 from ares.code_agents.terminus2 import terminus2_agent
 from ares.containers import containers
 from ares.environments import base
@@ -93,6 +95,7 @@ class HarborSpec:
             code_agent_factory=self.code_agent_factory,
             step_limit=self.step_limit,
             tracker=tracker,
+            artifact_root=pathlib.Path("logs") if self.code_agent_id == "opencode" else None,
         )
 
 
@@ -148,6 +151,7 @@ def _register_default_presets() -> None:
 
         for code_agent_id, code_agent_factory, step_limit in [
             ("mswea", _make_mswea_factory(ds_spec), 0),
+            ("opencode", opencode_agent.OpenCodeAgent, code_env.DEFAULT_STEP_LIMIT),
             ("terminus2", terminus2_agent.Terminus2Agent, code_env.DEFAULT_STEP_LIMIT),
         ]:
             registry.register_preset(


### PR DESCRIPTION
# User description
## Summary
- run OpenCode inside Harbor task sandboxes through the ARES proxy and expose its OpenAI Responses requests through the normal environment loop
- convert atomic ARES actions into buffered Responses SSE, including structured tool calls, while suppressing non-task title requests safely
- persist OpenCode, mediated request/action, proxy, verifier, and reward artifacts before sandbox cleanup
- extend `ares-proxy` to intercept Chat Completions, Responses, and Anthropic Messages endpoints with response content-type metadata
- fix container name and directory transfer handling required by real Terminal-Bench runs

## Validation
- `uv run pytest -q` (200 passed)
- `uv run ruff format --check`
- `uv run ruff check`
- targeted `uv run pyright` on changed Python files
- `docker run --rm -v \"$PWD:/src\" -w /src golang:1.24-alpine go test ./...`
- `RUN_OPENCODE_INTEGRATION=1 uv run pytest -q integration_tests/opencode_agent_test.py`
- real sequential `tbench-opencode` runs with GPT-5 Mini and GPT-5.5

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add <code>OpenCodeAgent</code> support to run OpenCode in Harbor sandboxes through the ARES proxy and normal environment loop. Extend <code>ares-proxy</code>, Responses conversion, tool-call handling, artifact persistence, container utilities, and environment presets to mediate requests, buffer SSE responses, suppress title generation, and retain execution logs.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/109?tool=ast&topic=Proxy+and+API+mediation>Proxy and API mediation</a>
        </td><td>Extend <code>ares-proxy</code> to broker Chat Completions, Responses, and Anthropic Messages requests with endpoint and content-type metadata, while improving Responses conversion, tool-call preservation, container transfers, and sandbox-safe naming.<details><summary>Modified files (16)</summary><ul><li>ares-proxy/README.md</li>
<li>ares-proxy/broker.go</li>
<li>ares-proxy/broker_test.go</li>
<li>ares-proxy/main.go</li>
<li>ares-proxy/main_test.go</li>
<li>ares-proxy/types.go</li>
<li>pyproject.toml</li>
<li>src/ares/containers/containers.py</li>
<li>src/ares/environments/base.py</li>
<li>src/ares/environments/base_test.py</li>
<li>src/ares/llms/__init__.py</li>
<li>src/ares/llms/chat_completions_compatible.py</li>
<li>src/ares/llms/chat_completions_compatible_test.py</li>
<li>src/ares/llms/openai_responses_converter.py</li>
<li>src/ares/llms/openai_responses_converter_test.py</li>
<li>src/ares/llms/response.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Add OpenCode agent sup...</td><td>August 07, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Add the ARES proxy (#84)</td><td>February 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/109?tool=ast&topic=OpenCode+sandbox+flow>OpenCode sandbox flow</a>
        </td><td>Run <code>OpenCodeAgent</code> inside task sandboxes through a localhost <code>ares-proxy</code>, translate atomic ARES responses into Responses SSE with tool calls, filter title requests, and persist agent and mediated artifacts.<details><summary>Modified files (8)</summary><ul><li>README.md</li>
<li>examples/02_sequential_eval_with_api.py</li>
<li>integration_tests/opencode_agent_test.py</li>
<li>src/ares/code_agents/opencode_agent.py</li>
<li>src/ares/code_agents/opencode_agent_test.py</li>
<li>src/ares/environments/code_env.py</li>
<li>src/ares/environments/code_env_test.py</li>
<li>src/ares/presets.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Add OpenCode agent sup...</td><td>August 07, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Update Discord link in...</td><td>February 17, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/withmartian/ares/109?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>