### PR TITLE
Extend ARES proxy protocols

### DIFF
--- a/ares-proxy/README.md
+++ b/ares-proxy/README.md
@@ -1,8 +1,8 @@
 # ares-proxy
 
-A lightweight HTTP proxy server that intercepts OpenAI-compatible chat completion requests and routes them through a queue-mediated polling system. Designed for use with the ARES (Agentic Research and Evaluation Suite) framework to enable RL-based control of LLM interactions.
+A lightweight HTTP proxy server that intercepts LLM API requests and routes them through a queue-mediated polling system. Designed for use with the ARES (Agentic Research and Evaluation Suite) framework to enable RL-based control of LLM interactions.
 
-The proxy doesn't validate the request/response types; this should be handled by the clients.
+The proxy validates JSON syntax but not provider request/response schemas; schema validation belongs in the controller.
 
 ## Overview
 
@@ -22,8 +22,8 @@ This architecture enables the ARES RL loop to intercept and control LLM interact
 │ (Agent)     │         │              │         │ (RL Environment)│
 └─────────────┘         └──────────────┘         └─────────────────┘
      │                         │                          │
-     │ POST /v1/chat/          │ GET /poll                │
-     │   completions           │ (retrieve requests)      │
+     │ POST /v1/...            │ GET /poll                │
+     │ (blocks waiting)        │ (retrieve requests)      │
      │ (blocks waiting)        │◀─────────────────────────┤
      │                         │                          │
      │                         │ POST /respond            │
@@ -42,23 +42,27 @@ The core coordination engine that manages:
 
 #### HTTP Endpoints (`main.go`)
 
-1. **`POST /v1/chat/completions`**
-   - OpenAI-compatible endpoint for LLM clients
-   - Accepts standard chat completion requests
+1. **Intercepted LLM endpoints**
+   - `POST /v1/chat/completions` for OpenAI-compatible Chat Completions clients
+   - `POST /v1/responses` for OpenAI Responses clients
+   - `POST /v1/messages` for Anthropic Messages clients
+   - Accept raw request JSON without schema validation
    - Blocks until a response is available or timeout occurs
-   - Returns the response as JSON
+   - Returns the response using the content type supplied by the controller
 
 2. **`GET /poll`**
    - Retrieves all pending requests from the queue
    - Clears the queue atomically
    - Returns an array of pending requests, each containing:
      - `id`: Unique request identifier
+     - `endpoint`: The intercepted API path
      - `timestamp`: When the request was submitted
-     - `request`: The original request payload (chat completion JSON)
+     - `request`: The original request payload JSON
 
 3. **`POST /respond`**
    - Sends a response back to a waiting request
    - Requires request ID and response payload
+   - Accepts an optional `content_type`; `application/json` is the default and `text/event-stream` carries buffered SSE
    - Returns error if request ID not found (e.g., timed out)
 
 ## Configuration
@@ -96,9 +100,11 @@ go build -o ares-proxy
 PORT=9000 TIMEOUT_MINUTES=30 ./ares-proxy
 ```
 
+The proxy binds to localhost because its control endpoints are intentionally unauthenticated and are only used from within the sandbox.
+
 ### Client Usage
 
-Configure your LLM client to point at the proxy:
+Configure your LLM client to point at the proxy. The proxy currently intercepts Chat Completions, OpenAI Responses, and Anthropic Messages requests under `/v1`.
 
 ```python
 from openai import OpenAI
@@ -130,17 +136,19 @@ requests_list = response.json()
 
 for req in requests_list:
     request_id = req["id"]
+    endpoint = req["endpoint"]
     request_body = req["request"]
 
     # Process the request (e.g., send to real LLM)
-    llm_response = process_request(request_body)
+    llm_response = process_request(endpoint, request_body)
 
     # Send response back to waiting client
     requests.post(
         "http://localhost:8080/respond",
         json={
             "id": request_id,
-            "response": llm_response
+            "response": llm_response,
+            "content_type": "application/json",
         }
     )
 ```
@@ -166,6 +174,7 @@ Tests run automatically in CI via GitHub Actions when any files in `ares-proxy/`
 ```
 ares-proxy/
 ├── main.go         # HTTP server and endpoint handlers
+├── main_test.go    # HTTP endpoint tests
 ├── broker.go       # Core request/response coordination logic
 ├── broker_test.go  # Unit tests for broker
 ├── config.go       # Configuration loading
@@ -187,6 +196,8 @@ ares-proxy is designed to work with ARES's `QueueMediatedLLMClient`. The integra
 7. Proxy unblocks and returns response to code agent
 
 This architecture allows ARES to treat LLM interactions as part of the RL loop without agents needing to be modified.
+
+ARES actions are atomic rather than token streams. For streaming clients, the controller sends a complete SSE body to `/respond`; the proxy returns that buffered stream with `Content-Type: text/event-stream`.
 
 ## Error Handling
 

--- a/ares-proxy/README.md
+++ b/ares-proxy/README.md
@@ -63,6 +63,7 @@ The core coordination engine that manages:
    - Sends a response back to a waiting request
    - Requires request ID and response payload
    - Accepts an optional `content_type`; `application/json` is the default and `text/event-stream` carries buffered SSE
+   - Non-JSON bodies, including buffered SSE, are JSON strings in the `/respond` envelope and become raw HTTP response bytes at this boundary
    - Returns error if request ID not found (e.g., timed out)
 
 ## Configuration
@@ -100,7 +101,7 @@ go build -o ares-proxy
 PORT=9000 TIMEOUT_MINUTES=30 ./ares-proxy
 ```
 
-The proxy binds to localhost because its control endpoints are intentionally unauthenticated and are only used from within the sandbox.
+The proxy binds to localhost because its control endpoints are intentionally unauthenticated and are only used from within a dedicated task sandbox. The ARES client invokes `/poll` and `/respond` through the container execution API, so no sandbox port exposure is required.
 
 ### Client Usage
 

--- a/ares-proxy/broker.go
+++ b/ares-proxy/broker.go
@@ -13,7 +13,7 @@ import (
 // Broker manages pending requests and coordinates responses
 type Broker struct {
 	// pendingRequests maps request ID to a response channel
-	pendingRequests map[string]chan json.RawMessage
+	pendingRequests map[string]chan ProxyResponse
 	// requestQueue holds requests waiting to be polled
 	requestQueue []PendingRequest
 	// mu protects both maps from concurrent access
@@ -25,26 +25,27 @@ type Broker struct {
 // NewBroker creates a new broker with the given timeout
 func NewBroker(timeout time.Duration) *Broker {
 	return &Broker{
-		pendingRequests: make(map[string]chan json.RawMessage),
+		pendingRequests: make(map[string]chan ProxyResponse),
 		requestQueue:    make([]PendingRequest, 0),
 		timeout:         timeout,
 	}
 }
 
-// SubmitRequest adds a request to the queue and waits for a response
-// This is called by the /v1/chat/completions endpoint
-func (b *Broker) SubmitRequest(ctx context.Context, requestBody json.RawMessage) (json.RawMessage, error) {
+// SubmitRequest adds a request to the queue and waits for a response.
+// This is called by the intercepted LLM API endpoints.
+func (b *Broker) SubmitRequest(ctx context.Context, endpoint string, requestBody json.RawMessage) (ProxyResponse, error) {
 	// Generate a unique ID for this request
 	id := uuid.New().String()
 
 	// Create a channel to receive the response
-	responseChan := make(chan json.RawMessage, 1)
+	responseChan := make(chan ProxyResponse, 1)
 
 	// Add to pending requests
 	b.mu.Lock()
 	b.pendingRequests[id] = responseChan
 	b.requestQueue = append(b.requestQueue, PendingRequest{
 		ID:        id,
+		Endpoint:  endpoint,
 		Request:   requestBody,
 		Timestamp: time.Now(),
 	})
@@ -61,14 +62,14 @@ func (b *Broker) SubmitRequest(ctx context.Context, requestBody json.RawMessage)
 		delete(b.pendingRequests, id)
 		b.removePendingRequestFromQueue(id)
 		b.mu.Unlock()
-		return nil, fmt.Errorf("request timeout after %s", b.timeout)
+		return ProxyResponse{}, fmt.Errorf("request timeout after %s", b.timeout)
 	case <-ctx.Done():
 		// Client disconnected - clean up both map and queue
 		b.mu.Lock()
 		delete(b.pendingRequests, id)
 		b.removePendingRequestFromQueue(id)
 		b.mu.Unlock()
-		return nil, ctx.Err()
+		return ProxyResponse{}, ctx.Err()
 	}
 }
 
@@ -103,7 +104,7 @@ func (b *Broker) PollRequests() []PendingRequest {
 
 // RespondToRequest sends a response back to a waiting request
 // This is called by the /respond endpoint
-func (b *Broker) RespondToRequest(id string, response json.RawMessage) error {
+func (b *Broker) RespondToRequest(id string, response ProxyResponse) error {
 	b.mu.Lock()
 	responseChan, exists := b.pendingRequests[id]
 	if !exists {

--- a/ares-proxy/broker.go
+++ b/ares-proxy/broker.go
@@ -51,26 +51,37 @@ func (b *Broker) SubmitRequest(ctx context.Context, endpoint string, requestBody
 	})
 	b.mu.Unlock()
 
+	timer := time.NewTimer(b.timeout)
+	defer timer.Stop()
+
 	// Wait for response with timeout
 	select {
 	case response := <-responseChan:
 		// Got a response!
 		return response, nil
-	case <-time.After(b.timeout):
-		// Timeout - clean up both map and queue
-		b.mu.Lock()
-		delete(b.pendingRequests, id)
-		b.removePendingRequestFromQueue(id)
-		b.mu.Unlock()
-		return ProxyResponse{}, fmt.Errorf("request timeout after %s", b.timeout)
+	case <-timer.C:
+		if b.expireRequest(id) {
+			return ProxyResponse{}, fmt.Errorf("request timeout after %s", b.timeout)
+		}
+		return <-responseChan, nil
 	case <-ctx.Done():
-		// Client disconnected - clean up both map and queue
-		b.mu.Lock()
-		delete(b.pendingRequests, id)
-		b.removePendingRequestFromQueue(id)
-		b.mu.Unlock()
-		return ProxyResponse{}, ctx.Err()
+		if b.expireRequest(id) {
+			return ProxyResponse{}, ctx.Err()
+		}
+		return <-responseChan, nil
 	}
+}
+
+// expireRequest claims a pending request for expiration.
+func (b *Broker) expireRequest(id string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, exists := b.pendingRequests[id]; !exists {
+		return false
+	}
+	delete(b.pendingRequests, id)
+	b.removePendingRequestFromQueue(id)
+	return true
 }
 
 // removePendingRequestFromQueue removes a request from the queue by ID
@@ -111,13 +122,11 @@ func (b *Broker) RespondToRequest(id string, response ProxyResponse) error {
 		b.mu.Unlock()
 		return fmt.Errorf("request ID %s not found (may have timed out)", id)
 	}
-	// Remove from pending requests
+	// Claim the request and deliver while holding the lock so expiration cannot win afterward.
 	delete(b.pendingRequests, id)
-	b.mu.Unlock()
-
-	// Send response (non-blocking since channel is buffered)
 	responseChan <- response
 	close(responseChan)
+	b.mu.Unlock()
 
 	return nil
 }

--- a/ares-proxy/broker_test.go
+++ b/ares-proxy/broker_test.go
@@ -7,6 +7,10 @@ import (
 	"time"
 )
 
+func jsonProxyResponse(body json.RawMessage) ProxyResponse {
+	return ProxyResponse{Body: body, ContentType: "application/json"}
+}
+
 func TestBroker_SubmitAndPoll(t *testing.T) {
 	broker := NewBroker(1 * time.Minute)
 
@@ -14,10 +18,10 @@ func TestBroker_SubmitAndPoll(t *testing.T) {
 	testRequest := json.RawMessage(`{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}`)
 
 	// Submit request in background
-	responseChan := make(chan json.RawMessage, 1)
+	responseChan := make(chan ProxyResponse, 1)
 	go func() {
 		ctx := context.Background()
-		response, err := broker.SubmitRequest(ctx, testRequest)
+		response, err := broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
 		if err != nil {
 			t.Errorf("SubmitRequest failed: %v", err)
 			return
@@ -37,10 +41,13 @@ func TestBroker_SubmitAndPoll(t *testing.T) {
 	if string(pending[0].Request) != string(testRequest) {
 		t.Errorf("Request mismatch: got %s, want %s", pending[0].Request, testRequest)
 	}
+	if pending[0].Endpoint != "/v1/chat/completions" {
+		t.Errorf("Endpoint mismatch: got %s, want /v1/chat/completions", pending[0].Endpoint)
+	}
 
 	// Send response
 	testResponse := json.RawMessage(`{"id": "test", "choices": [{"message": {"role": "assistant", "content": "Hi"}}]}`)
-	err := broker.RespondToRequest(pending[0].ID, testResponse)
+	err := broker.RespondToRequest(pending[0].ID, jsonProxyResponse(testResponse))
 	if err != nil {
 		t.Fatalf("RespondToRequest failed: %v", err)
 	}
@@ -48,8 +55,8 @@ func TestBroker_SubmitAndPoll(t *testing.T) {
 	// Verify the original SubmitRequest call received the response
 	select {
 	case response := <-responseChan:
-		if string(response) != string(testResponse) {
-			t.Errorf("Response mismatch: got %s, want %s", response, testResponse)
+		if string(response.Body) != string(testResponse) {
+			t.Errorf("Response mismatch: got %s, want %s", response.Body, testResponse)
 		}
 	case <-time.After(1 * time.Second):
 		t.Fatal("Timeout waiting for response")
@@ -60,15 +67,15 @@ func TestBroker_MultipleConcurrentRequests(t *testing.T) {
 	broker := NewBroker(1 * time.Minute)
 
 	numRequests := 5
-	responses := make([]chan json.RawMessage, numRequests)
+	responses := make([]chan ProxyResponse, numRequests)
 
 	// Submit multiple requests concurrently
 	for i := 0; i < numRequests; i++ {
-		responses[i] = make(chan json.RawMessage, 1)
+		responses[i] = make(chan ProxyResponse, 1)
 		go func(idx int) {
 			ctx := context.Background()
 			req := json.RawMessage(`{"request": "` + string(rune('A'+idx)) + `"}`)
-			response, err := broker.SubmitRequest(ctx, req)
+			response, err := broker.SubmitRequest(ctx, "/v1/chat/completions", req)
 			if err != nil {
 				t.Errorf("Submit %d failed: %v", idx, err)
 				return
@@ -89,7 +96,7 @@ func TestBroker_MultipleConcurrentRequests(t *testing.T) {
 	// Respond to all
 	testResponse := json.RawMessage(`{"response": "ok"}`)
 	for _, req := range pending {
-		err := broker.RespondToRequest(req.ID, testResponse)
+		err := broker.RespondToRequest(req.ID, jsonProxyResponse(testResponse))
 		if err != nil {
 			t.Errorf("Respond failed for %s: %v", req.ID, err)
 		}
@@ -120,7 +127,7 @@ func TestBroker_RespondToNonexistentRequest(t *testing.T) {
 	broker := NewBroker(1 * time.Minute)
 
 	testResponse := json.RawMessage(`{"response": "test"}`)
-	err := broker.RespondToRequest("nonexistent-id", testResponse)
+	err := broker.RespondToRequest("nonexistent-id", jsonProxyResponse(testResponse))
 	if err == nil {
 		t.Error("Expected error when responding to nonexistent request")
 	}
@@ -138,7 +145,7 @@ func TestBroker_Timeout(t *testing.T) {
 	ctx := context.Background()
 
 	// Submit will timeout because no one responds
-	_, err := broker.SubmitRequest(ctx, testRequest)
+	_, err := broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
 	if err == nil {
 		t.Fatal("Expected timeout error, got nil")
 	}
@@ -163,7 +170,7 @@ func TestBroker_ContextCancellation(t *testing.T) {
 	// Submit in background
 	errChan := make(chan error, 1)
 	go func() {
-		_, err := broker.SubmitRequest(ctx, testRequest)
+		_, err := broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
 		errChan <- err
 	}()
 
@@ -200,7 +207,7 @@ func TestBroker_PollClearsQueue(t *testing.T) {
 	go func() {
 		ctx := context.Background()
 		testRequest := json.RawMessage(`{"test": "request"}`)
-		broker.SubmitRequest(ctx, testRequest)
+		broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
 	}()
 
 	// Give it time to queue
@@ -228,7 +235,7 @@ func TestBroker_RequestTimestamp(t *testing.T) {
 	go func() {
 		ctx := context.Background()
 		testRequest := json.RawMessage(`{"test": "request"}`)
-		broker.SubmitRequest(ctx, testRequest)
+		broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
 	}()
 
 	// Give it time to queue
@@ -262,13 +269,13 @@ func TestBroker_ExactlyOnceDelivery(t *testing.T) {
 
 	// Submit all requests
 	go func() {
-		broker.SubmitRequest(ctx1, testRequest1)
+		broker.SubmitRequest(ctx1, "/v1/chat/completions", testRequest1)
 	}()
 	go func() {
-		broker.SubmitRequest(ctx2, testRequest2) // Will timeout
+		broker.SubmitRequest(ctx2, "/v1/chat/completions", testRequest2) // Will timeout
 	}()
 	go func() {
-		broker.SubmitRequest(ctx3, testRequest3)
+		broker.SubmitRequest(ctx3, "/v1/chat/completions", testRequest3)
 	}()
 
 	// Give them time to queue
@@ -288,7 +295,7 @@ func TestBroker_ExactlyOnceDelivery(t *testing.T) {
 
 	// Respond to request 1 only
 	testResponse := json.RawMessage(`{"response": "ok"}`)
-	err := broker.RespondToRequest(pending1[0].ID, testResponse)
+	err := broker.RespondToRequest(pending1[0].ID, jsonProxyResponse(testResponse))
 	if err != nil {
 		t.Errorf("Failed to respond to request 1: %v", err)
 	}
@@ -306,12 +313,12 @@ func TestBroker_ExactlyOnceDelivery(t *testing.T) {
 	}
 
 	// Verify we can't respond to timed-out or cancelled requests
-	err = broker.RespondToRequest(pending1[1].ID, testResponse)
+	err = broker.RespondToRequest(pending1[1].ID, jsonProxyResponse(testResponse))
 	if err == nil {
 		t.Error("Expected error when responding to timed-out request")
 	}
 
-	err = broker.RespondToRequest(pending1[2].ID, testResponse)
+	err = broker.RespondToRequest(pending1[2].ID, jsonProxyResponse(testResponse))
 	if err == nil {
 		t.Error("Expected error when responding to cancelled request")
 	}

--- a/ares-proxy/broker_test.go
+++ b/ares-proxy/broker_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 )
@@ -202,12 +203,14 @@ func TestBroker_ContextCancellation(t *testing.T) {
 
 func TestBroker_PollClearsQueue(t *testing.T) {
 	broker := NewBroker(1 * time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultChan := make(chan error, 1)
 
 	// Submit a request
 	go func() {
-		ctx := context.Background()
 		testRequest := json.RawMessage(`{"test": "request"}`)
-		broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
+		_, err := broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
+		resultChan <- err
 	}()
 
 	// Give it time to queue
@@ -224,18 +227,25 @@ func TestBroker_PollClearsQueue(t *testing.T) {
 	if len(pending2) != 0 {
 		t.Errorf("Expected empty queue after poll, got %d requests", len(pending2))
 	}
+
+	cancel()
+	if err := <-resultChan; !errors.Is(err, context.Canceled) {
+		t.Fatalf("SubmitRequest error = %v, want context.Canceled", err)
+	}
 }
 
 func TestBroker_RequestTimestamp(t *testing.T) {
 	broker := NewBroker(1 * time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultChan := make(chan error, 1)
 
 	before := time.Now()
 
 	// Submit a request
 	go func() {
-		ctx := context.Background()
 		testRequest := json.RawMessage(`{"test": "request"}`)
-		broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
+		_, err := broker.SubmitRequest(ctx, "/v1/chat/completions", testRequest)
+		resultChan <- err
 	}()
 
 	// Give it time to queue
@@ -253,10 +263,21 @@ func TestBroker_RequestTimestamp(t *testing.T) {
 	if ts.Before(before) || ts.After(after) {
 		t.Errorf("Timestamp %v not between %v and %v", ts, before, after)
 	}
+
+	cancel()
+	if err := <-resultChan; !errors.Is(err, context.Canceled) {
+		t.Fatalf("SubmitRequest error = %v, want context.Canceled", err)
+	}
 }
 
 func TestBroker_ExactlyOnceDelivery(t *testing.T) {
 	broker := NewBroker(200 * time.Millisecond)
+	type result struct {
+		request  string
+		response ProxyResponse
+		err      error
+	}
+	results := make(chan result, 3)
 
 	// Submit 3 requests: one normal, one that will timeout, one that will be cancelled
 	ctx1 := context.Background()
@@ -267,16 +288,16 @@ func TestBroker_ExactlyOnceDelivery(t *testing.T) {
 	testRequest2 := json.RawMessage(`{"request": "2"}`)
 	testRequest3 := json.RawMessage(`{"request": "3"}`)
 
-	// Submit all requests
-	go func() {
-		broker.SubmitRequest(ctx1, "/v1/chat/completions", testRequest1)
-	}()
-	go func() {
-		broker.SubmitRequest(ctx2, "/v1/chat/completions", testRequest2) // Will timeout
-	}()
-	go func() {
-		broker.SubmitRequest(ctx3, "/v1/chat/completions", testRequest3)
-	}()
+	// Submit all requests and associate results with their request bodies.
+	submit := func(ctx context.Context, request json.RawMessage) {
+		go func() {
+			response, err := broker.SubmitRequest(ctx, "/v1/chat/completions", request)
+			results <- result{request: string(request), response: response, err: err}
+		}()
+	}
+	submit(ctx1, testRequest1)
+	submit(ctx2, testRequest2)
+	submit(ctx3, testRequest3)
 
 	// Give them time to queue
 	time.Sleep(50 * time.Millisecond)
@@ -293,9 +314,14 @@ func TestBroker_ExactlyOnceDelivery(t *testing.T) {
 		t.Errorf("Expected empty queue after first poll, got %d requests", len(pending2))
 	}
 
+	pendingByRequest := make(map[string]PendingRequest, len(pending1))
+	for _, pending := range pending1 {
+		pendingByRequest[string(pending.Request)] = pending
+	}
+
 	// Respond to request 1 only
 	testResponse := json.RawMessage(`{"response": "ok"}`)
-	err := broker.RespondToRequest(pending1[0].ID, jsonProxyResponse(testResponse))
+	err := broker.RespondToRequest(pendingByRequest[string(testRequest1)].ID, jsonProxyResponse(testResponse))
 	if err != nil {
 		t.Errorf("Failed to respond to request 1: %v", err)
 	}
@@ -303,8 +329,20 @@ func TestBroker_ExactlyOnceDelivery(t *testing.T) {
 	// Cancel request 3
 	cancel3()
 
-	// Wait for request 2 to timeout
-	time.Sleep(200 * time.Millisecond)
+	resultsByRequest := make(map[string]result, 3)
+	for range 3 {
+		result := <-results
+		resultsByRequest[result.request] = result
+	}
+	if result := resultsByRequest[string(testRequest1)]; result.err != nil || string(result.response.Body) != string(testResponse) {
+		t.Fatalf("request 1 result = (%s, %v), want response and nil error", result.response.Body, result.err)
+	}
+	if result := resultsByRequest[string(testRequest2)]; result.err == nil {
+		t.Fatal("request 2 did not time out")
+	}
+	if result := resultsByRequest[string(testRequest3)]; !errors.Is(result.err, context.Canceled) {
+		t.Fatalf("request 3 error = %v, want context.Canceled", result.err)
+	}
 
 	// Poll again - should still be empty (stale requests shouldn't reappear)
 	pending3 := broker.PollRequests()
@@ -313,13 +351,57 @@ func TestBroker_ExactlyOnceDelivery(t *testing.T) {
 	}
 
 	// Verify we can't respond to timed-out or cancelled requests
-	err = broker.RespondToRequest(pending1[1].ID, jsonProxyResponse(testResponse))
+	err = broker.RespondToRequest(pendingByRequest[string(testRequest2)].ID, jsonProxyResponse(testResponse))
 	if err == nil {
 		t.Error("Expected error when responding to timed-out request")
 	}
 
-	err = broker.RespondToRequest(pending1[2].ID, jsonProxyResponse(testResponse))
+	err = broker.RespondToRequest(pendingByRequest[string(testRequest3)].ID, jsonProxyResponse(testResponse))
 	if err == nil {
 		t.Error("Expected error when responding to cancelled request")
+	}
+}
+
+func TestBroker_ResponseAndTimeoutAreMutuallyExclusive(t *testing.T) {
+	for range 25 {
+		const timeout = 50 * time.Millisecond
+		broker := NewBroker(timeout)
+		resultChan := make(chan struct {
+			response ProxyResponse
+			err      error
+		}, 1)
+		go func() {
+			response, err := broker.SubmitRequest(
+				context.Background(),
+				"/v1/responses",
+				json.RawMessage(`{"input":"test"}`),
+			)
+			resultChan <- struct {
+				response ProxyResponse
+				err      error
+			}{response: response, err: err}
+		}()
+
+		var pending []PendingRequest
+		deadline := time.Now().Add(timeout / 2)
+		for len(pending) == 0 && time.Now().Before(deadline) {
+			pending = broker.PollRequests()
+			time.Sleep(100 * time.Microsecond)
+		}
+		if len(pending) != 1 {
+			t.Fatalf("Expected 1 pending request, got %d", len(pending))
+		}
+		time.Sleep(time.Until(pending[0].Timestamp.Add(timeout)))
+		response := jsonProxyResponse(json.RawMessage(`{"id":"response"}`))
+		respondErr := broker.RespondToRequest(pending[0].ID, response)
+		result := <-resultChan
+
+		if respondErr == nil {
+			if result.err != nil || string(result.response.Body) != string(response.Body) {
+				t.Fatalf("/respond succeeded but SubmitRequest returned (%s, %v)", result.response.Body, result.err)
+			}
+		} else if result.err == nil {
+			t.Fatalf("/respond failed with %v but SubmitRequest returned success", respondErr)
+		}
 	}
 }

--- a/ares-proxy/main.go
+++ b/ares-proxy/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 )
 
 func main() {
@@ -64,7 +65,7 @@ func handleLLMRequest(broker *Broker) http.HandlerFunc {
 
 		// Send the response back to the client
 		w.Header().Set("Content-Type", response.ContentType)
-		if response.ContentType == "text/event-stream" {
+		if strings.HasPrefix(response.ContentType, "text/event-stream") {
 			w.Header().Set("Cache-Control", "no-cache")
 			w.Header().Set("Connection", "keep-alive")
 		}

--- a/ares-proxy/main.go
+++ b/ares-proxy/main.go
@@ -50,7 +50,6 @@ func handleLLMRequest(broker *Broker) http.HandlerFunc {
 			http.Error(w, fmt.Sprintf("Failed to read request: %v", err), http.StatusBadRequest)
 			return
 		}
-		defer r.Body.Close()
 		if !json.Valid(body) {
 			http.Error(w, "Invalid JSON", http.StatusBadRequest)
 			return
@@ -69,7 +68,9 @@ func handleLLMRequest(broker *Broker) http.HandlerFunc {
 			w.Header().Set("Cache-Control", "no-cache")
 			w.Header().Set("Connection", "keep-alive")
 		}
-		w.Write(response.Body)
+		if _, err := w.Write(response.Body); err != nil {
+			log.Printf("Failed to write LLM response: %v", err)
+		}
 	}
 }
 
@@ -109,8 +110,6 @@ func handleRespond(broker *Broker) http.HandlerFunc {
 			http.Error(w, fmt.Sprintf("Invalid JSON: %v", err), http.StatusBadRequest)
 			return
 		}
-		defer r.Body.Close()
-
 		proxyResponse, err := req.ProxyResponse()
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Invalid response: %v", err), http.StatusBadRequest)
@@ -125,6 +124,8 @@ func handleRespond(broker *Broker) http.HandlerFunc {
 
 		// Acknowledge success
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"status": "ok"}); err != nil {
+			log.Printf("Failed to write response acknowledgement: %v", err)
+		}
 	}
 }

--- a/ares-proxy/main.go
+++ b/ares-proxy/main.go
@@ -16,22 +16,28 @@ func main() {
 	// Create the broker
 	broker := NewBroker(config.Timeout)
 
-	// Set up HTTP routes
-	http.HandleFunc("/v1/chat/completions", handleChatCompletion(broker))
-	http.HandleFunc("/poll", handlePoll(broker))
-	http.HandleFunc("/respond", handleRespond(broker))
+	mux := http.NewServeMux()
+	registerRoutes(mux, broker)
 
 	// Start the server
-	addr := ":" + config.Port
+	addr := "127.0.0.1:" + config.Port
 	log.Printf("Server listening on %s", addr)
-	if err := http.ListenAndServe(addr, nil); err != nil {
+	if err := http.ListenAndServe(addr, mux); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
 }
 
-// handleChatCompletion handles POST /v1/chat/completions
-// This holds the request and waits for a response
-func handleChatCompletion(broker *Broker) http.HandlerFunc {
+func registerRoutes(mux *http.ServeMux, broker *Broker) {
+	mux.HandleFunc("/v1/chat/completions", handleLLMRequest(broker))
+	mux.HandleFunc("/v1/responses", handleLLMRequest(broker))
+	mux.HandleFunc("/v1/messages", handleLLMRequest(broker))
+	mux.HandleFunc("/poll", handlePoll(broker))
+	mux.HandleFunc("/respond", handleRespond(broker))
+}
+
+// handleLLMRequest handles intercepted LLM API requests.
+// This holds the request and waits for a response.
+func handleLLMRequest(broker *Broker) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -45,17 +51,25 @@ func handleChatCompletion(broker *Broker) http.HandlerFunc {
 			return
 		}
 		defer r.Body.Close()
+		if !json.Valid(body) {
+			http.Error(w, "Invalid JSON", http.StatusBadRequest)
+			return
+		}
 
 		// Submit the request and wait for response
-		response, err := broker.SubmitRequest(r.Context(), json.RawMessage(body))
+		response, err := broker.SubmitRequest(r.Context(), r.URL.Path, json.RawMessage(body))
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Request failed: %v", err), http.StatusInternalServerError)
 			return
 		}
 
 		// Send the response back to the client
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(response)
+		w.Header().Set("Content-Type", response.ContentType)
+		if response.ContentType == "text/event-stream" {
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+		}
+		w.Write(response.Body)
 	}
 }
 
@@ -97,8 +111,14 @@ func handleRespond(broker *Broker) http.HandlerFunc {
 		}
 		defer r.Body.Close()
 
+		proxyResponse, err := req.ProxyResponse()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid response: %v", err), http.StatusBadRequest)
+			return
+		}
+
 		// Send the response to the waiting request
-		if err := broker.RespondToRequest(req.ID, req.Response); err != nil {
+		if err := broker.RespondToRequest(req.ID, proxyResponse); err != nil {
 			http.Error(w, fmt.Sprintf("Failed to respond: %v", err), http.StatusNotFound)
 			return
 		}

--- a/ares-proxy/main_test.go
+++ b/ares-proxy/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +15,33 @@ import (
 type receivedResponse struct {
 	body        string
 	contentType string
+	statusCode  int
+}
+
+func doRequest(client *http.Client, method string, url string, body io.Reader) (receivedResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return receivedResponse{}, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return receivedResponse{}, err
+	}
+	responseBody, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		return receivedResponse{}, readErr
+	}
+	if closeErr != nil {
+		return receivedResponse{}, closeErr
+	}
+	return receivedResponse{
+		body:        string(responseBody),
+		contentType: resp.Header.Get("Content-Type"),
+		statusCode:  resp.StatusCode,
+	}, nil
 }
 
 func newTestServer(broker *Broker) *httptest.Server {
@@ -27,22 +55,16 @@ func pollUntilRequest(t *testing.T, client *http.Client, serverURL string) Pendi
 
 	deadline := time.Now().Add(1 * time.Second)
 	for time.Now().Before(deadline) {
-		resp, err := client.Get(serverURL + "/poll")
+		resp, err := doRequest(client, http.MethodGet, serverURL+"/poll", nil)
 		if err != nil {
 			t.Fatalf("poll failed: %v", err)
 		}
-
-		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			t.Fatalf("failed to read poll response: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("poll status = %d, body = %s", resp.StatusCode, body)
+		if resp.statusCode != http.StatusOK {
+			t.Fatalf("poll status = %d, body = %s", resp.statusCode, resp.body)
 		}
 
 		var pending []PendingRequest
-		if err := json.Unmarshal(body, &pending); err != nil {
+		if err := json.Unmarshal([]byte(resp.body), &pending); err != nil {
 			t.Fatalf("failed to decode poll response: %v", err)
 		}
 		if len(pending) > 0 {
@@ -81,18 +103,12 @@ func respondToRequest(
 	if err != nil {
 		t.Fatalf("failed to encode respond request: %v", err)
 	}
-	resp, err := client.Post(serverURL+"/respond", "application/json", bytes.NewReader(body))
+	resp, err := doRequest(client, http.MethodPost, serverURL+"/respond", bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("respond failed: %v", err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatalf("failed to read respond response: %v", err)
-		}
-		t.Fatalf("respond status = %d, body = %s", resp.StatusCode, body)
+	if resp.statusCode != http.StatusOK {
+		t.Fatalf("respond status = %d, body = %s", resp.statusCode, resp.body)
 	}
 }
 
@@ -136,27 +152,21 @@ func TestLLMEndpoints_RouteRawRequests(t *testing.T) {
 			responseChan := make(chan receivedResponse, 1)
 			errorChan := make(chan error, 1)
 			go func() {
-				resp, err := server.Client().Post(
+				resp, err := doRequest(
+					server.Client(),
+					http.MethodPost,
 					server.URL+tc.endpoint,
-					"application/json",
 					bytes.NewBufferString(tc.request),
 				)
 				if err != nil {
 					errorChan <- err
 					return
 				}
-				defer resp.Body.Close()
-
-				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					errorChan <- err
+				if resp.statusCode != http.StatusOK {
+					errorChan <- fmt.Errorf("status = %d, body = %s", resp.statusCode, resp.body)
 					return
 				}
-				if resp.StatusCode != http.StatusOK {
-					errorChan <- fmt.Errorf("status = %d, body = %s", resp.StatusCode, body)
-					return
-				}
-				responseChan <- receivedResponse{body: string(body), contentType: resp.Header.Get("Content-Type")}
+				responseChan <- resp
 			}()
 
 			pending := pollUntilRequest(t, server.Client(), server.URL)
@@ -193,14 +203,12 @@ func TestLLMEndpoints_RejectNonPost(t *testing.T) {
 
 	for _, endpoint := range []string{"/v1/chat/completions", "/v1/responses", "/v1/messages"} {
 		t.Run(endpoint, func(t *testing.T) {
-			resp, err := server.Client().Get(server.URL + endpoint)
+			resp, err := doRequest(server.Client(), http.MethodGet, server.URL+endpoint, nil)
 			if err != nil {
 				t.Fatalf("request failed: %v", err)
 			}
-			defer resp.Body.Close()
-
-			if resp.StatusCode != http.StatusMethodNotAllowed {
-				t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusMethodNotAllowed)
+			if resp.statusCode != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want %d", resp.statusCode, http.StatusMethodNotAllowed)
 			}
 		})
 	}
@@ -211,18 +219,17 @@ func TestLLMEndpoints_RejectInvalidJSON(t *testing.T) {
 	server := newTestServer(broker)
 	defer server.Close()
 
-	resp, err := server.Client().Post(
+	resp, err := doRequest(
+		server.Client(),
+		http.MethodPost,
 		server.URL+"/v1/responses",
-		"application/json",
 		bytes.NewBufferString("not-json"),
 	)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	if resp.statusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.statusCode, http.StatusBadRequest)
 	}
 	if pending := broker.PollRequests(); len(pending) != 0 {
 		t.Fatalf("invalid request was queued: %v", pending)

--- a/ares-proxy/main_test.go
+++ b/ares-proxy/main_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type receivedResponse struct {
+	body        string
+	contentType string
+}
+
+func newTestServer(broker *Broker) *httptest.Server {
+	mux := http.NewServeMux()
+	registerRoutes(mux, broker)
+	return httptest.NewServer(mux)
+}
+
+func pollUntilRequest(t *testing.T, client *http.Client, serverURL string) PendingRequest {
+	t.Helper()
+
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(serverURL + "/poll")
+		if err != nil {
+			t.Fatalf("poll failed: %v", err)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			t.Fatalf("failed to read poll response: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("poll status = %d, body = %s", resp.StatusCode, body)
+		}
+
+		var pending []PendingRequest
+		if err := json.Unmarshal(body, &pending); err != nil {
+			t.Fatalf("failed to decode poll response: %v", err)
+		}
+		if len(pending) > 0 {
+			if len(pending) != 1 {
+				t.Fatalf("expected 1 pending request, got %d", len(pending))
+			}
+			return pending[0]
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal("timed out waiting for pending request")
+	return PendingRequest{}
+}
+
+func respondToRequest(
+	t *testing.T,
+	client *http.Client,
+	serverURL string,
+	id string,
+	response string,
+	contentType string,
+) {
+	t.Helper()
+
+	var responseValue any = json.RawMessage(response)
+	if contentType != "application/json" {
+		responseValue = response
+	}
+	body, err := json.Marshal(map[string]any{
+		"id":           id,
+		"response":     responseValue,
+		"content_type": contentType,
+	})
+	if err != nil {
+		t.Fatalf("failed to encode respond request: %v", err)
+	}
+	resp, err := client.Post(serverURL+"/respond", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("respond failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("failed to read respond response: %v", err)
+		}
+		t.Fatalf("respond status = %d, body = %s", resp.StatusCode, body)
+	}
+}
+
+func TestLLMEndpoints_RouteRawRequests(t *testing.T) {
+	testCases := []struct {
+		name        string
+		endpoint    string
+		request     string
+		response    string
+		contentType string
+	}{
+		{
+			name:        "chat completions",
+			endpoint:    "/v1/chat/completions",
+			request:     `{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`,
+			response:    `{"id":"chatcmpl-test","choices":[{"message":{"role":"assistant","content":"hi"}}]}`,
+			contentType: "application/json",
+		},
+		{
+			name:        "openai responses",
+			endpoint:    "/v1/responses",
+			request:     `{"model":"gpt-5","input":[{"role":"user","content":[{"type":"input_text","text":"hello"}]}],"stream":true}`,
+			response:    "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n",
+			contentType: "text/event-stream",
+		},
+		{
+			name:        "anthropic messages",
+			endpoint:    "/v1/messages",
+			request:     `{"model":"claude-sonnet","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}],"stream":true,"max_tokens":4096}`,
+			response:    `{"id":"msg-test","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}]}`,
+			contentType: "application/json",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			broker := NewBroker(1 * time.Minute)
+			server := newTestServer(broker)
+			defer server.Close()
+
+			responseChan := make(chan receivedResponse, 1)
+			errorChan := make(chan error, 1)
+			go func() {
+				resp, err := server.Client().Post(
+					server.URL+tc.endpoint,
+					"application/json",
+					bytes.NewBufferString(tc.request),
+				)
+				if err != nil {
+					errorChan <- err
+					return
+				}
+				defer resp.Body.Close()
+
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					errorChan <- err
+					return
+				}
+				if resp.StatusCode != http.StatusOK {
+					errorChan <- fmt.Errorf("status = %d, body = %s", resp.StatusCode, body)
+					return
+				}
+				responseChan <- receivedResponse{body: string(body), contentType: resp.Header.Get("Content-Type")}
+			}()
+
+			pending := pollUntilRequest(t, server.Client(), server.URL)
+			if pending.Endpoint != tc.endpoint {
+				t.Fatalf("endpoint = %q, want %q", pending.Endpoint, tc.endpoint)
+			}
+			if string(pending.Request) != tc.request {
+				t.Fatalf("request = %s, want %s", pending.Request, tc.request)
+			}
+
+			respondToRequest(t, server.Client(), server.URL, pending.ID, tc.response, tc.contentType)
+
+			select {
+			case err := <-errorChan:
+				t.Fatal(err)
+			case response := <-responseChan:
+				if response.body != tc.response {
+					t.Fatalf("response = %s, want %s", response.body, tc.response)
+				}
+				if response.contentType != tc.contentType {
+					t.Fatalf("content type = %q, want %q", response.contentType, tc.contentType)
+				}
+			case <-time.After(1 * time.Second):
+				t.Fatal("timed out waiting for LLM endpoint response")
+			}
+		})
+	}
+}
+
+func TestLLMEndpoints_RejectNonPost(t *testing.T) {
+	broker := NewBroker(1 * time.Minute)
+	server := newTestServer(broker)
+	defer server.Close()
+
+	for _, endpoint := range []string{"/v1/chat/completions", "/v1/responses", "/v1/messages"} {
+		t.Run(endpoint, func(t *testing.T) {
+			resp, err := server.Client().Get(server.URL + endpoint)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusMethodNotAllowed)
+			}
+		})
+	}
+}
+
+func TestLLMEndpoints_RejectInvalidJSON(t *testing.T) {
+	broker := NewBroker(1 * time.Minute)
+	server := newTestServer(broker)
+	defer server.Close()
+
+	resp, err := server.Client().Post(
+		server.URL+"/v1/responses",
+		"application/json",
+		bytes.NewBufferString("not-json"),
+	)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if pending := broker.PollRequests(); len(pending) != 0 {
+		t.Fatalf("invalid request was queued: %v", pending)
+	}
+}

--- a/ares-proxy/main_test.go
+++ b/ares-proxy/main_test.go
@@ -132,7 +132,7 @@ func TestLLMEndpoints_RouteRawRequests(t *testing.T) {
 			endpoint:    "/v1/responses",
 			request:     `{"model":"gpt-5","input":[{"role":"user","content":[{"type":"input_text","text":"hello"}]}],"stream":true}`,
 			response:    "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n",
-			contentType: "text/event-stream",
+			contentType: "text/event-stream; charset=utf-8",
 		},
 		{
 			name:        "anthropic messages",
@@ -233,5 +233,24 @@ func TestLLMEndpoints_RejectInvalidJSON(t *testing.T) {
 	}
 	if pending := broker.PollRequests(); len(pending) != 0 {
 		t.Fatalf("invalid request was queued: %v", pending)
+	}
+}
+
+func TestRespondRejectsMissingResponse(t *testing.T) {
+	broker := NewBroker(1 * time.Minute)
+	server := newTestServer(broker)
+	defer server.Close()
+
+	resp, err := doRequest(
+		server.Client(),
+		http.MethodPost,
+		server.URL+"/respond",
+		bytes.NewBufferString(`{"id":"request-id"}`),
+	)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.statusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.statusCode, http.StatusBadRequest)
 	}
 }

--- a/ares-proxy/types.go
+++ b/ares-proxy/types.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"mime"
 	"time"
 )
 
@@ -30,16 +31,30 @@ type ProxyResponse struct {
 
 // ProxyResponse converts a RespondRequest to a ProxyResponse for the intercepted LLM client.
 func (r RespondRequest) ProxyResponse() (ProxyResponse, error) {
-	contentType := r.ContentType
-	if contentType == "" || contentType == "application/json" {
-		return ProxyResponse{Body: r.Response, ContentType: "application/json"}, nil
+	if len(r.Response) == 0 {
+		return ProxyResponse{}, fmt.Errorf("response is required")
 	}
-	if contentType != "text/event-stream" {
+
+	contentType := r.ContentType
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return ProxyResponse{}, fmt.Errorf("invalid content type %q: %w", contentType, err)
+	}
+	contentType = mime.FormatMediaType(mediaType, params)
+
+	if mediaType == "application/json" {
+		return ProxyResponse{Body: r.Response, ContentType: contentType}, nil
+	}
+	if mediaType != "text/event-stream" {
 		return ProxyResponse{}, fmt.Errorf("unsupported content type %q", contentType)
 	}
 
+	// Non-JSON bodies travel inside /respond's JSON envelope as strings, then become raw HTTP bytes here.
 	var body string
-	if err := json.Unmarshal(r.Response, &body); err != nil {
+	if err = json.Unmarshal(r.Response, &body); err != nil {
 		return ProxyResponse{}, fmt.Errorf("response must be a JSON string for content type %q: %w", contentType, err)
 	}
 

--- a/ares-proxy/types.go
+++ b/ares-proxy/types.go
@@ -28,6 +28,7 @@ type ProxyResponse struct {
 	ContentType string
 }
 
+// ProxyResponse converts a RespondRequest to a ProxyResponse for the intercepted LLM client.
 func (r RespondRequest) ProxyResponse() (ProxyResponse, error) {
 	contentType := r.ContentType
 	if contentType == "" || contentType == "application/json" {

--- a/ares-proxy/types.go
+++ b/ares-proxy/types.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -9,12 +10,37 @@ import (
 // This is what gets returned from the /poll endpoint
 type PendingRequest struct {
 	ID        string          `json:"id"`
+	Endpoint  string          `json:"endpoint"`
 	Request   json.RawMessage `json:"request"` // The raw JSON blob from the client
 	Timestamp time.Time       `json:"timestamp"`
 }
 
 // RespondRequest is sent to the /respond endpoint
 type RespondRequest struct {
-	ID       string          `json:"id"`
-	Response json.RawMessage `json:"response"` // The raw JSON response to send back
+	ID          string          `json:"id"`
+	Response    json.RawMessage `json:"response"`
+	ContentType string          `json:"content_type,omitempty"`
+}
+
+// ProxyResponse is returned to the intercepted LLM client.
+type ProxyResponse struct {
+	Body        []byte
+	ContentType string
+}
+
+func (r RespondRequest) ProxyResponse() (ProxyResponse, error) {
+	contentType := r.ContentType
+	if contentType == "" || contentType == "application/json" {
+		return ProxyResponse{Body: r.Response, ContentType: "application/json"}, nil
+	}
+	if contentType != "text/event-stream" {
+		return ProxyResponse{}, fmt.Errorf("unsupported content type %q", contentType)
+	}
+
+	var body string
+	if err := json.Unmarshal(r.Response, &body); err != nil {
+		return ProxyResponse{}, fmt.Errorf("response must be a JSON string for content type %q: %w", contentType, err)
+	}
+
+	return ProxyResponse{Body: []byte(body), ContentType: contentType}, nil
 }


### PR DESCRIPTION
# User description
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Extend the ARES proxy broker and HTTP handlers to support OpenAI Responses, Anthropic Messages, and Chat Completions endpoints with endpoint-aware request routing. Preserve response content types, including buffered SSE streams, while validating JSON syntax and enforcing atomic response delivery.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/110?tool=ast&topic=Multi-Protocol+Routing>Multi-Protocol Routing</a>
        </td><td>Support multiple LLM API flows by routing endpoint paths through the broker and returning JSON or buffered SSE responses with validated content types.<details><summary>Modified files (5)</summary><ul><li>ares-proxy/README.md</li>
<li>ares-proxy/broker.go</li>
<li>ares-proxy/main.go</li>
<li>ares-proxy/main_test.go</li>
<li>ares-proxy/types.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Harden proxy response ...</td><td>August 07, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Add the ARES proxy (#84)</td><td>February 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/110?tool=ast&topic=Reliable+Response+Delivery>Reliable Response Delivery</a>
        </td><td>Guarantee exactly-once broker delivery by coordinating timeout, cancellation, and response races under lock and covering these behaviors with concurrency tests.<details><summary>Modified files (2)</summary><ul><li>ares-proxy/broker.go</li>
<li>ares-proxy/broker_test.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Address proxy review f...</td><td>August 07, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Add the ARES proxy (#84)</td><td>February 03, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/withmartian/ares/110?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Chat Completions, OpenAI Responses, and Anthropic Messages endpoints.
  * Preserved endpoint metadata and response content types, including buffered Server-Sent Events (SSE).
  * Added JSON validation and support for text and streaming responses.
  * Restricted server binding to localhost for improved security.
* **Bug Fixes**
  * Invalid JSON and unsupported response formats now return clear errors.
  * Non-POST requests and invalid response submissions are rejected appropriately.
  * Improved reliability when delivering responses during timeouts or cancellations.
* **Documentation**
  * Updated usage guidance and examples for expanded endpoint and response support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->