### PR TITLE
Preserve LLM tool calls

### DIFF
--- a/src/ares/llms/__init__.py
+++ b/src/ares/llms/__init__.py
@@ -14,6 +14,7 @@ from ares.llms.request import UserMessage
 # Response types
 from ares.llms.response import LLMResponse
 from ares.llms.response import TextData
+from ares.llms.response import ToolCallData
 from ares.llms.response import Usage
 
 __all__ = [
@@ -24,6 +25,7 @@ __all__ = [
     "LLMResponse",
     "Message",
     "TextData",
+    "ToolCallData",
     "ToolCallMessage",
     "ToolCallResponseMessage",
     "Usage",

--- a/src/ares/llms/chat_completions_compatible.py
+++ b/src/ares/llms/chat_completions_compatible.py
@@ -72,9 +72,24 @@ class ChatCompletionCompatibleLLMClient(llm_clients.LLMClient):
         cost = accounting.get_llm_cost(self.model, resp, cost_mapping=accounting.martian_cost_list())
         cost = float(cost)
 
-        content = resp.choices[0].message.content or ""
+        message = resp.choices[0].message
+        content = message.content or ""
+        tool_calls = [
+            response.ToolCallData(
+                call_id=tool_call.id,
+                name=tool_call.function.name,
+                arguments=tool_call.function.arguments,
+            )
+            for tool_call in (message.tool_calls or [])
+            if tool_call.type == "function"
+        ]
         usage = response.Usage(
             prompt_tokens=resp.usage.prompt_tokens if resp.usage else 0,
             generated_tokens=resp.usage.completion_tokens if resp.usage else 0,
         )
-        return response.LLMResponse(data=[response.TextData(content=content)], cost=cost, usage=usage)
+        return response.LLMResponse(
+            data=[response.TextData(content=content)],
+            cost=cost,
+            usage=usage,
+            tool_calls=tool_calls,
+        )

--- a/src/ares/llms/chat_completions_compatible_test.py
+++ b/src/ares/llms/chat_completions_compatible_test.py
@@ -1,9 +1,15 @@
 """Tests for the Chat Completions-compatible LLM client."""
 
+import decimal
+
+import frozendict
+import openai
 import openai.types.chat.chat_completion
 import pytest
 
+from ares.llms import accounting
 from ares.llms import chat_completions_compatible
+from ares.llms import request
 
 
 @pytest.mark.asyncio
@@ -35,17 +41,29 @@ async def test_client_preserves_tool_calls(monkeypatch: pytest.MonkeyPatch) -> N
         }
     )
 
-    async def query(*args, **kwargs):
-        del args, kwargs
+    async def query(
+        llm_client: openai.AsyncClient,
+        model: str,
+        req: request.LLMRequest,
+    ) -> openai.types.chat.chat_completion.ChatCompletion:
+        del llm_client, model, req
         return completion
 
-    def get_cost(*args, **kwargs):
-        del args, kwargs
-        return 0.0
+    def get_cost(
+        model_id: str,
+        completion: openai.types.chat.chat_completion.ChatCompletion,
+        *,
+        cost_mapping: frozendict.frozendict[str, accounting.ModelCost],
+    ) -> decimal.Decimal:
+        del model_id, completion, cost_mapping
+        return decimal.Decimal(0)
+
+    def cost_list() -> frozendict.frozendict[str, accounting.ModelCost]:
+        return frozendict.frozendict()
 
     monkeypatch.setattr(chat_completions_compatible, "_query_llm_with_retry", query)
     monkeypatch.setattr(chat_completions_compatible.accounting, "get_llm_cost", get_cost)
-    monkeypatch.setattr(chat_completions_compatible.accounting, "martian_cost_list", lambda: {})
+    monkeypatch.setattr(chat_completions_compatible.accounting, "martian_cost_list", cost_list)
 
     client = chat_completions_compatible.ChatCompletionCompatibleLLMClient(
         model="test-model",

--- a/src/ares/llms/chat_completions_compatible_test.py
+++ b/src/ares/llms/chat_completions_compatible_test.py
@@ -1,0 +1,62 @@
+"""Tests for the Chat Completions-compatible LLM client."""
+
+import openai.types.chat.chat_completion
+import pytest
+
+from ares.llms import chat_completions_compatible
+
+
+@pytest.mark.asyncio
+async def test_client_preserves_tool_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    completion = openai.types.chat.chat_completion.ChatCompletion.model_validate(
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_123",
+                                "type": "function",
+                                "function": {"name": "bash", "arguments": '{"command":"pwd"}'},
+                            }
+                        ],
+                    },
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14},
+        }
+    )
+
+    async def query(*args, **kwargs):
+        del args, kwargs
+        return completion
+
+    def get_cost(*args, **kwargs):
+        del args, kwargs
+        return 0.0
+
+    monkeypatch.setattr(chat_completions_compatible, "_query_llm_with_retry", query)
+    monkeypatch.setattr(chat_completions_compatible.accounting, "get_llm_cost", get_cost)
+    monkeypatch.setattr(chat_completions_compatible.accounting, "martian_cost_list", lambda: {})
+
+    client = chat_completions_compatible.ChatCompletionCompatibleLLMClient(
+        model="test-model",
+        base_url="http://unused",
+        api_key="unused",
+    )
+    result = await client(
+        chat_completions_compatible.request.LLMRequest(messages=[{"role": "user", "content": "Run pwd"}])
+    )
+
+    assert result.data[0].content == ""
+    assert result.tool_calls[0].call_id == "call_123"
+    assert result.tool_calls[0].name == "bash"
+    assert result.tool_calls[0].arguments == '{"command":"pwd"}'

--- a/src/ares/llms/openai_responses_converter.py
+++ b/src/ares/llms/openai_responses_converter.py
@@ -12,25 +12,39 @@ Conversion Notes:
     - messages converted to/from input items
 """
 
+from collections.abc import Iterable
 import logging
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import openai.types.responses
+from openai.types.responses import response_input_message_content_list_param
+from openai.types.responses import response_output_message_param
 import openai.types.responses.response_create_params
 
 from ares.llms import request as llm_request
 
 _LOGGER = logging.getLogger(__name__)
 
+type _ResponsesContentBlock = (
+    response_input_message_content_list_param.ResponseInputContentParam | response_output_message_param.Content
+)
+type _ResponsesMessageContent = str | Iterable[_ResponsesContentBlock]
+type _ResponsesMessageRole = Literal["user", "assistant", "system", "developer"]
 
-def _message_content_from_responses(content: Any, *, strict: bool, role: str) -> str:
+
+def _message_content_from_responses(
+    content: _ResponsesMessageContent,
+    *,
+    strict: bool,
+    role: _ResponsesMessageRole,
+) -> str:
     """Extract text from Responses API message content."""
-    if not isinstance(content, list):
-        return llm_request._extract_string_content(content, strict=strict, context=f"Message content (role={role})")
+    if isinstance(content, str):
+        return content
 
     text_parts = []
     for block in content:
-        if isinstance(block, dict) and block.get("type") in {"input_text", "output_text", "text"}:
+        if block.get("type") in {"input_text", "output_text"}:
             text = block.get("text", "")
             if isinstance(text, str):
                 text_parts.append(text)
@@ -395,9 +409,14 @@ def from_external(
             # EasyInputMessage permits omitting type when role is present.
             elif item_type == "message" or (item_type is None and "role" in item):
                 role = item.get("role")
+                content = cast(_ResponsesMessageContent, item.get("content", ""))
 
                 if role in {"system", "developer"}:
-                    content_str = _message_content_from_responses(item.get("content", ""), strict=strict, role=role)
+                    content_str = _message_content_from_responses(
+                        content,
+                        strict=strict,
+                        role=cast(_ResponsesMessageRole, role),
+                    )
                     system_prompt = "\n\n".join(part for part in [system_prompt, content_str] if part)
                     continue
 
@@ -408,7 +427,11 @@ def from_external(
                     _LOGGER.warning("Skipping message with unsupported role: %s", role)
                     continue
 
-                content_str = _message_content_from_responses(item.get("content", ""), strict=strict, role=role)
+                content_str = _message_content_from_responses(
+                    content,
+                    strict=strict,
+                    role=cast(_ResponsesMessageRole, role),
+                )
 
                 # Build message dict with required fields
                 message_dict: dict[str, Any] = {"role": role, "content": content_str}

--- a/src/ares/llms/openai_responses_converter.py
+++ b/src/ares/llms/openai_responses_converter.py
@@ -23,6 +23,27 @@ from ares.llms import request as llm_request
 _LOGGER = logging.getLogger(__name__)
 
 
+def _message_content_from_responses(content: Any, *, strict: bool, role: str) -> str:
+    """Extract text from Responses API message content."""
+    if not isinstance(content, list):
+        return llm_request._extract_string_content(content, strict=strict, context=f"Message content (role={role})")
+
+    text_parts = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") in {"input_text", "output_text", "text"}:
+            text = block.get("text", "")
+            if isinstance(text, str):
+                text_parts.append(text)
+                continue
+
+        msg = f"Unsupported Responses message content block for role={role}: {block}"
+        if strict:
+            raise ValueError(msg)
+        _LOGGER.warning(msg)
+
+    return "".join(text_parts)
+
+
 def _tool_to_responses(tool: llm_request.Tool) -> openai.types.responses.FunctionToolParam:
     """Convert Tool from ARES internal format to OpenAI Responses format.
 
@@ -294,6 +315,7 @@ def from_external(
         "metadata",
         "service_tier",
         "instructions",
+        "store",  # Response persistence is provider-side state and is intentionally ignored.
     }
 
     # Check for unhandled parameters
@@ -307,6 +329,7 @@ def from_external(
     # Convert input items to messages
     input_param = kwargs.get("input", [])
     filtered_messages: list[llm_request.Message] = []
+    system_prompt = kwargs.get("instructions")
 
     if isinstance(input_param, str):
         filtered_messages = [llm_request.UserMessage(role="user", content=input_param)]
@@ -327,6 +350,10 @@ def from_external(
                         )
                     _LOGGER.warning("Tool call (function_call) missing required fields, skipping. Item: %s", item)
                     continue
+
+                previous = filtered_messages[-1] if filtered_messages else None
+                if previous is None or (previous.get("role") != "assistant" and "call_id" not in previous):
+                    filtered_messages.append(llm_request.AssistantMessage(role="assistant", content=""))
 
                 # Create ToolCallMessage
                 filtered_messages.append(
@@ -365,9 +392,14 @@ def from_external(
                         cast(llm_request.Message, {"role": "tool", "content": output_str, "tool_call_id": call_id})
                     )
 
-            # Handle regular messages
-            elif item_type == "message":
+            # EasyInputMessage permits omitting type when role is present.
+            elif item_type == "message" or (item_type is None and "role" in item):
                 role = item.get("role")
+
+                if role in {"system", "developer"}:
+                    content_str = _message_content_from_responses(item.get("content", ""), strict=strict, role=role)
+                    system_prompt = "\n\n".join(part for part in [system_prompt, content_str] if part)
+                    continue
 
                 # Validate role is supported
                 if role not in llm_request._VALID_ROLES:
@@ -376,11 +408,7 @@ def from_external(
                     _LOGGER.warning("Skipping message with unsupported role: %s", role)
                     continue
 
-                # Extract content - use helper to detect unsupported block formats
-                content_param = item.get("content", "")
-                content_str = llm_request._extract_string_content(
-                    content_param, strict=strict, context=f"Message content (role={role})"
-                )
+                content_str = _message_content_from_responses(item.get("content", ""), strict=strict, role=role)
 
                 # Build message dict with required fields
                 message_dict: dict[str, Any] = {"role": role, "content": content_str}
@@ -431,5 +459,5 @@ def from_external(
         tool_choice=resolved_tool_choice,
         metadata=cast(dict[str, Any] | None, kwargs.get("metadata")),
         service_tier=kwargs.get("service_tier"),
-        system_prompt=kwargs.get("instructions"),
+        system_prompt=system_prompt,
     )

--- a/src/ares/llms/openai_responses_converter_test.py
+++ b/src/ares/llms/openai_responses_converter_test.py
@@ -35,7 +35,7 @@ class TestStructuredContentHandling:
             openai_responses_converter.from_external(kwargs, strict=True)
 
     def test_from_responses_with_structured_content_non_strict(self):
-        """Test that structured content returns empty string in non-strict mode."""
+        """Test non-strict conversion preserves text and skips unsupported blocks."""
         kwargs = openai.types.responses.response_create_params.ResponseCreateParamsBase(
             model="gpt-4",
             input=[

--- a/src/ares/llms/openai_responses_converter_test.py
+++ b/src/ares/llms/openai_responses_converter_test.py
@@ -31,7 +31,7 @@ class TestStructuredContentHandling:
             ],
         )
 
-        with pytest.raises(ValueError, match=r"list of blocks.*structured content"):
+        with pytest.raises(ValueError, match="Unsupported Responses message content block"):
             openai_responses_converter.from_external(kwargs, strict=True)
 
     def test_from_responses_with_structured_content_non_strict(self):
@@ -52,10 +52,10 @@ class TestStructuredContentHandling:
             ],
         )
 
-        # Should not raise, but content will be empty
+        # Unsupported blocks are skipped without losing supported text blocks.
         request = openai_responses_converter.from_external(kwargs, strict=False)
         assert len(request.messages) == 1
-        assert request.messages[0].get("content") == ""
+        assert request.messages[0].get("content") == "Hello"
 
 
 class TestLLMRequestResponsesConversion:
@@ -201,19 +201,33 @@ class TestLLMRequestResponsesConversion:
 
         assert list(request.messages) == [{"role": "user", "content": "Hello, world!"}]
 
-    def test_from_responses_list_input(self):
-        """Test parsing Responses with list input."""
-        kwargs: openai.types.responses.response_create_params.ResponseCreateParams = {
-            "model": "gpt-4o",
-            "input": [
-                {"type": "message", "role": "user", "content": "Hello"},
-                {"type": "message", "role": "assistant", "content": "Hi!"},
-            ],
-        }
+    def test_from_responses_opencode_easy_input_messages(self):
+        """Test OpenCode's block content and omitted message type."""
+        kwargs = cast(
+            openai.types.responses.response_create_params.ResponseCreateParams,
+            {
+                "model": "ares",
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "Hello"},
+                            {"type": "input_text", "text": ", world!"},
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Hi!"}],
+                    },
+                ],
+                "stream": True,
+            },
+        )
+
         request = openai_responses_converter.from_external(kwargs)
 
-        assert list(request.messages) == [
-            {"role": "user", "content": "Hello"},
+        assert request.messages == [
+            {"role": "user", "content": "Hello, world!"},
             {"role": "assistant", "content": "Hi!"},
         ]
 
@@ -320,7 +334,8 @@ class TestLLMRequestResponsesConversion:
         )
         request = openai_responses_converter.from_external(kwargs)
 
-        tool_call_msg = request.messages[1]
+        assert request.messages[1] == {"role": "assistant", "content": ""}
+        tool_call_msg = request.messages[2]
         assert "call_id" in tool_call_msg
         assert tool_call_msg["call_id"] == "call_456"  # type: ignore[typeddict-item]
         assert tool_call_msg["name"] == "get_weather"  # type: ignore[typeddict-item]

--- a/src/ares/llms/response.py
+++ b/src/ares/llms/response.py
@@ -24,6 +24,15 @@ class TextData:
 
 
 @dataclasses.dataclass(frozen=True)
+class ToolCallData:
+    """A function call requested by the LLM."""
+
+    call_id: str
+    name: str
+    arguments: str
+
+
+@dataclasses.dataclass(frozen=True)
 class LLMResponse:
     """Response from an LLM call.
 
@@ -31,8 +40,10 @@ class LLMResponse:
         data: List of content blocks (currently only TextData, but extensible to ImageData, etc.)
         cost: Cost of the LLM call in USD.
         usage: Token usage information.
+        tool_calls: Function calls requested by the LLM.
     """
 
     data: list[TextData]
     cost: float
     usage: Usage
+    tool_calls: list[ToolCallData] = dataclasses.field(default_factory=list)


### PR DESCRIPTION
# User description
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Preserve LLM-requested function calls across compatible chat completions by adding <code>ToolCallData</code> to <code>LLMResponse</code> and exporting it through the LLM package. Improve OpenAI Responses conversion by handling structured text, system prompts, omitted message types, tool-call assistant messages, and ignored provider state.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/111?tool=ast&topic=Tool+Call+Preservation>Tool Call Preservation</a>
        </td><td>Preserve function calls returned by compatible chat models in <code>LLMResponse</code>, including identifiers, function names, and arguments, with coverage for tool-call-only responses.<details><summary>Modified files (4)</summary><ul><li>src/ares/llms/__init__.py</li>
<li>src/ares/llms/chat_completions_compatible.py</li>
<li>src/ares/llms/chat_completions_compatible_test.py</li>
<li>src/ares/llms/response.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Address LLM test revie...</td><td>August 07, 2026</td></tr>
<tr><td>Narmeen07</td><td>Add mechanistic interp...</td><td>February 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/111?tool=ast&topic=Responses+Conversion>Responses Conversion</a>
        </td><td>Convert OpenAI Responses message formats more robustly by joining supported text blocks, preserving system instructions, recognizing easy-input messages, and inserting assistant context before tool results.<details><summary>Modified files (2)</summary><ul><li>src/ares/llms/openai_responses_converter.py</li>
<li>src/ares/llms/openai_responses_converter_test.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Address LLM test revie...</td><td>August 07, 2026</td></tr>
<tr><td>sarvanithin</td><td>Refactor LLMRequest co...</td><td>February 13, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/withmartian/ares/111?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving function tool-call details, including call IDs, names, and arguments.
  * LLM responses now expose tool calls alongside generated text.
  * Improved compatibility with structured and role-based messages across Responses API integrations.

* **Bug Fixes**
  * Corrected handling of system instructions, assistant messages, and standalone function calls.
  * Improved validation and warnings for unsupported content blocks.

* **Tests**
  * Added and updated coverage for tool-call metadata and structured message conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->