### PR TITLE
Serialize Responses API streams

### DIFF
--- a/src/ares/llms/openai_responses_stream.py
+++ b/src/ares/llms/openai_responses_stream.py
@@ -9,6 +9,7 @@ from ares.llms import response
 
 
 def _sse_event(event: dict[str, Any]) -> str:
+    """Serialize one Responses event in SSE wire format."""
     return f"event: {event['type']}\ndata: {json.dumps(event, separators=(',', ':'))}\n\n"
 
 
@@ -20,6 +21,7 @@ def to_sse(llm_response: response.LLMResponse, *, model: str) -> str:
     sequence_number = 0
 
     def add_event(event_type: str, **values: Any) -> None:
+        """Append one event with the next sequence number."""
         nonlocal sequence_number
         events.append({"type": event_type, "sequence_number": sequence_number, **values})
         sequence_number += 1
@@ -31,6 +33,9 @@ def to_sse(llm_response: response.LLMResponse, *, model: str) -> str:
         "status": "in_progress",
         "model": model,
         "output": [],
+        "parallel_tool_calls": True,
+        "tool_choice": "auto",
+        "tools": [],
     }
     add_event("response.created", response=response_base)
     add_event("response.in_progress", response=response_base)
@@ -105,7 +110,6 @@ def to_sse(llm_response: response.LLMResponse, *, model: str) -> str:
             "response.function_call_arguments.done",
             item_id=item_id,
             output_index=output_index,
-            name=tool_call.name,
             arguments=tool_call.arguments,
         )
         completed_item = {**empty_item, "status": "completed", "arguments": tool_call.arguments}
@@ -114,7 +118,9 @@ def to_sse(llm_response: response.LLMResponse, *, model: str) -> str:
 
     usage = {
         "input_tokens": llm_response.usage.prompt_tokens,
+        "input_tokens_details": {"cached_tokens": 0},
         "output_tokens": llm_response.usage.generated_tokens,
+        "output_tokens_details": {"reasoning_tokens": 0},
         "total_tokens": llm_response.usage.total_tokens,
     }
     add_event(

--- a/src/ares/llms/openai_responses_stream.py
+++ b/src/ares/llms/openai_responses_stream.py
@@ -1,0 +1,124 @@
+"""Serialize atomic ARES responses as OpenAI Responses SSE streams."""
+
+import json
+import time
+from typing import Any
+import uuid
+
+from ares.llms import response
+
+
+def _sse_event(event: dict[str, Any]) -> str:
+    return f"event: {event['type']}\ndata: {json.dumps(event, separators=(',', ':'))}\n\n"
+
+
+def to_sse(llm_response: response.LLMResponse, *, model: str) -> str:
+    """Convert one atomic ARES response into a complete Responses API stream."""
+    response_id = f"resp_{uuid.uuid4().hex}"
+    output: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
+    sequence_number = 0
+
+    def add_event(event_type: str, **values: Any) -> None:
+        nonlocal sequence_number
+        events.append({"type": event_type, "sequence_number": sequence_number, **values})
+        sequence_number += 1
+
+    response_base: dict[str, Any] = {
+        "id": response_id,
+        "object": "response",
+        "created_at": int(time.time()),
+        "status": "in_progress",
+        "model": model,
+        "output": [],
+    }
+    add_event("response.created", response=response_base)
+    add_event("response.in_progress", response=response_base)
+
+    text = "".join(part.content for part in llm_response.data)
+    if text or not llm_response.tool_calls:
+        output_index = len(output)
+        item_id = f"msg_{uuid.uuid4().hex}"
+        empty_item = {
+            "id": item_id,
+            "type": "message",
+            "status": "in_progress",
+            "role": "assistant",
+            "content": [],
+        }
+        add_event("response.output_item.added", output_index=output_index, item=empty_item)
+        empty_part = {"type": "output_text", "text": "", "annotations": [], "logprobs": []}
+        add_event(
+            "response.content_part.added",
+            item_id=item_id,
+            output_index=output_index,
+            content_index=0,
+            part=empty_part,
+        )
+        add_event(
+            "response.output_text.delta",
+            item_id=item_id,
+            output_index=output_index,
+            content_index=0,
+            delta=text,
+            logprobs=[],
+        )
+        add_event(
+            "response.output_text.done",
+            item_id=item_id,
+            output_index=output_index,
+            content_index=0,
+            text=text,
+            logprobs=[],
+        )
+        completed_part = {"type": "output_text", "text": text, "annotations": [], "logprobs": []}
+        add_event(
+            "response.content_part.done",
+            item_id=item_id,
+            output_index=output_index,
+            content_index=0,
+            part=completed_part,
+        )
+        completed_item = {**empty_item, "status": "completed", "content": [completed_part]}
+        add_event("response.output_item.done", output_index=output_index, item=completed_item)
+        output.append(completed_item)
+
+    for tool_call in llm_response.tool_calls:
+        output_index = len(output)
+        item_id = f"fc_{uuid.uuid4().hex}"
+        empty_item = {
+            "id": item_id,
+            "type": "function_call",
+            "status": "in_progress",
+            "call_id": tool_call.call_id,
+            "name": tool_call.name,
+            "arguments": "",
+        }
+        add_event("response.output_item.added", output_index=output_index, item=empty_item)
+        add_event(
+            "response.function_call_arguments.delta",
+            item_id=item_id,
+            output_index=output_index,
+            delta=tool_call.arguments,
+        )
+        add_event(
+            "response.function_call_arguments.done",
+            item_id=item_id,
+            output_index=output_index,
+            name=tool_call.name,
+            arguments=tool_call.arguments,
+        )
+        completed_item = {**empty_item, "status": "completed", "arguments": tool_call.arguments}
+        add_event("response.output_item.done", output_index=output_index, item=completed_item)
+        output.append(completed_item)
+
+    usage = {
+        "input_tokens": llm_response.usage.prompt_tokens,
+        "output_tokens": llm_response.usage.generated_tokens,
+        "total_tokens": llm_response.usage.total_tokens,
+    }
+    add_event(
+        "response.completed",
+        response={**response_base, "status": "completed", "output": output, "usage": usage},
+    )
+    return "".join(_sse_event(event) for event in events)

--- a/src/ares/llms/openai_responses_stream_test.py
+++ b/src/ares/llms/openai_responses_stream_test.py
@@ -1,18 +1,26 @@
 """Tests for OpenAI Responses stream serialization."""
 
 import json
+from typing import Any
+
+import openai.types.responses
+import pydantic
 
 from ares.llms import openai_responses_stream
 from ares.llms import response
 
+_STREAM_EVENT_ADAPTER = pydantic.TypeAdapter(openai.types.responses.ResponseStreamEvent)
 
-def _parse_sse(stream: str) -> list[dict]:
-    events = []
+
+def _parse_sse(stream: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
     for block in stream.strip().split("\n\n"):
         lines = block.splitlines()
         assert lines[0].startswith("event: ")
         assert lines[1].startswith("data: ")
-        events.append(json.loads(lines[1].removeprefix("data: ")))
+        event: dict[str, Any] = json.loads(lines[1].removeprefix("data: "))
+        _STREAM_EVENT_ADAPTER.validate_python(event)
+        events.append(event)
     return events
 
 
@@ -48,6 +56,8 @@ def test_to_sse_serializes_text_and_tool_calls() -> None:
     assert function_call["arguments"] == '{"command":"pwd"}'
     assert events[-1]["response"]["usage"] == {
         "input_tokens": 12,
+        "input_tokens_details": {"cached_tokens": 0},
         "output_tokens": 7,
+        "output_tokens_details": {"reasoning_tokens": 0},
         "total_tokens": 19,
     }

--- a/src/ares/llms/openai_responses_stream_test.py
+++ b/src/ares/llms/openai_responses_stream_test.py
@@ -1,0 +1,53 @@
+"""Tests for OpenAI Responses stream serialization."""
+
+import json
+
+from ares.llms import openai_responses_stream
+from ares.llms import response
+
+
+def _parse_sse(stream: str) -> list[dict]:
+    events = []
+    for block in stream.strip().split("\n\n"):
+        lines = block.splitlines()
+        assert lines[0].startswith("event: ")
+        assert lines[1].startswith("data: ")
+        events.append(json.loads(lines[1].removeprefix("data: ")))
+    return events
+
+
+def test_to_sse_serializes_text_and_tool_calls() -> None:
+    llm_response = response.LLMResponse(
+        data=[response.TextData(content="Checking the repository.")],
+        cost=0.0,
+        usage=response.Usage(prompt_tokens=12, generated_tokens=7),
+        tool_calls=[
+            response.ToolCallData(
+                call_id="call_123",
+                name="bash",
+                arguments='{"command":"pwd"}',
+            )
+        ],
+    )
+
+    events = _parse_sse(openai_responses_stream.to_sse(llm_response, model="ares"))
+
+    event_types = [event["type"] for event in events]
+    assert event_types[0:2] == ["response.created", "response.in_progress"]
+    assert "response.output_text.delta" in event_types
+    assert "response.function_call_arguments.delta" in event_types
+    assert event_types[-1] == "response.completed"
+
+    function_call = next(
+        event["item"]
+        for event in events
+        if event["type"] == "response.output_item.done" and event["item"]["type"] == "function_call"
+    )
+    assert function_call["call_id"] == "call_123"
+    assert function_call["name"] == "bash"
+    assert function_call["arguments"] == '{"command":"pwd"}'
+    assert events[-1]["response"]["usage"] == {
+        "input_tokens": 12,
+        "output_tokens": 7,
+        "total_tokens": 19,
+    }

--- a/src/ares/llms/openai_responses_stream_test.py
+++ b/src/ares/llms/openai_responses_stream_test.py
@@ -20,6 +20,7 @@ def _parse_sse(stream: str) -> list[dict[str, Any]]:
         assert lines[1].startswith("data: ")
         event: dict[str, Any] = json.loads(lines[1].removeprefix("data: "))
         _STREAM_EVENT_ADAPTER.validate_python(event)
+        assert lines[0].removeprefix("event: ") == event["type"]
         events.append(event)
     return events
 


### PR DESCRIPTION
# User description
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add <code>to_sse</code> to serialize atomic ARES <code>LLMResponse</code> values into OpenAI Responses API SSE events, including text, function calls, sequencing, and usage metadata. Validate the generated stream against OpenAI response event types with coverage for text, tool calls, and token usage.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Assert SSE event names</td><td>August 07, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/withmartian/ares/112?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for streaming LLM responses through the OpenAI Responses API using Server-Sent Events.
  * Supports text output, function calls, tool metadata, arguments, lifecycle events, and token usage details.
  * Ensures response events are serialized in the expected order and format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->