### PR TITLE
Add OpenCode sandbox runner

### DIFF
--- a/src/ares/code_agents/opencode_cli.py
+++ b/src/ares/code_agents/opencode_cli.py
@@ -1,0 +1,79 @@
+"""Install, configure, and run OpenCode inside a sandbox."""
+
+import dataclasses
+import json
+import shlex
+
+from ares.containers import containers
+
+LOG_PATH = "/logs/agent/opencode.jsonl"
+PID_PATH = "/tmp/ares-opencode.pid"
+DEFAULT_VERSION = "1.14.48"
+
+
+@dataclasses.dataclass(kw_only=True)
+class OpenCodeCLI:
+    container: containers.Container
+    version: str = DEFAULT_VERSION
+
+    async def install(self) -> None:
+        command = " && ".join(
+            [
+                "if ! command -v curl >/dev/null; then "
+                "if command -v apt-get >/dev/null; then apt-get update && apt-get install -y curl ca-certificates; "
+                "elif command -v apk >/dev/null; then apk add --no-cache curl ca-certificates; "
+                "else echo 'curl is required' >&2; exit 1; fi; fi",
+                'if [ ! -s "$HOME/.nvm/nvm.sh" ]; then '
+                "curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash; fi",
+                '. "$HOME/.nvm/nvm.sh"',
+                "nvm install 22",
+                f"npm install -g opencode-ai@{shlex.quote(self.version)}",
+            ]
+        )
+        result = await self.container.exec_run(command, timeout_s=600)
+        if result.exit_code != 0:
+            raise RuntimeError(f"Failed to install OpenCode: {result.output}")
+
+    async def configure(self, proxy_url: str) -> None:
+        config = {
+            "$schema": "https://opencode.ai/config.json",
+            "agent": {"title": {"disable": True}},
+            "provider": {
+                "ares": {
+                    "name": "ARES",
+                    "npm": "@ai-sdk/openai",
+                    "env": [],
+                    "options": {"apiKey": "unused", "baseURL": f"{proxy_url}/v1"},
+                    "models": {
+                        "ares": {
+                            "name": "ARES-mediated model",
+                            "limit": {"context": 1_000_000, "output": 128_000},
+                        }
+                    },
+                }
+            },
+        }
+        config_json = shlex.quote(json.dumps(config, separators=(",", ":")))
+        result = await self.container.exec_run(
+            f'mkdir -p "$HOME/.config/opencode" && printf %s {config_json} > "$HOME/.config/opencode/opencode.json"'
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"Failed to configure OpenCode: {result.output}")
+
+    async def run(self, task: str) -> None:
+        command = (
+            '. "$HOME/.nvm/nvm.sh" && '
+            f"echo $$ > {PID_PATH} && "
+            "exec opencode --model=ares/ares run --format=json --thinking "
+            f"--dangerously-skip-permissions -- {shlex.quote(task)}"
+        )
+        result = await self.container.exec_run(
+            f"bash -lc {shlex.quote(command)} > {LOG_PATH} 2>&1",
+            env={"OPENCODE_FAKE_VCS": "git"},
+        )
+        if result.exit_code != 0:
+            log_result = await self.container.exec_run(f"tail -c 10000 {LOG_PATH}")
+            raise RuntimeError(f"OpenCode exited with code {result.exit_code}: {log_result.output}")
+
+    async def stop(self) -> None:
+        await self.container.exec_run(f"if [ -f {PID_PATH} ]; then kill $(cat {PID_PATH}) 2>/dev/null || true; fi")

--- a/src/ares/code_agents/opencode_cli_test.py
+++ b/src/ares/code_agents/opencode_cli_test.py
@@ -1,0 +1,23 @@
+"""Tests for the OpenCode sandbox runner."""
+
+import pytest
+
+from ares.code_agents import opencode_cli
+from ares.testing import mock_container
+
+
+@pytest.mark.asyncio
+async def test_opencode_cli_commands() -> None:
+    container = mock_container.MockContainer()
+    cli = opencode_cli.OpenCodeCLI(container=container)
+
+    await cli.install()
+    await cli.configure("http://localhost:8080")
+    await cli.run("Fix the bug")
+    await cli.stop()
+
+    assert any("npm install -g opencode-ai@1.14.48" in command for command in container.exec_commands)
+    assert any('"npm":"@ai-sdk/openai"' in command for command in container.exec_commands)
+    assert any('"agent":{"title":{"disable":true}}' in command for command in container.exec_commands)
+    assert any("opencode --model=ares/ares run" in command for command in container.exec_commands)
+    assert any("> /logs/agent/opencode.jsonl 2>&1" in command for command in container.exec_commands)


### PR DESCRIPTION
# User description
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add an <code>OpenCodeCLI</code> sandbox runner that installs OpenCode, configures its ARES-mediated provider, executes tasks with JSON logging, and supports stopping the process. Validate the install, configuration, execution, logging, and lifecycle commands with async tests.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Add OpenCode sandbox r...</td><td>August 07, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/withmartian/ares/115?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>