### PR TITLE
Expose OpenCode agent presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+Use the corresponding `-opencode` preset, such as `sbv-opencode`, to run OpenCode inside the task sandbox. ARES installs OpenCode, configures it to use the in-sandbox ARES proxy through the OpenAI Responses API, and exposes each OpenCode model request through the same `reset()`/`step()` loop. Building the Linux proxy binary requires Go or Docker on the ARES client.
+
+OpenCode presets disable session-title generation so only task-relevant requests enter the RL loop. Episode artifacts are saved under `logs/`, including OpenCode JSONL, mediated request/action JSONL, proxy logs, and verifier output.
+
 To run the example above you'll need a Martian API key set in your `.env` file. To get a key:
 
 1) Go to https://app.withmartian.com

--- a/examples/02_sequential_eval_with_api.py
+++ b/examples/02_sequential_eval_with_api.py
@@ -14,29 +14,40 @@ Prerequisites:
 Example usage:
 
     uv run -m examples.02_sequential_eval_with_api
+
+    uv run -m examples.02_sequential_eval_with_api \
+        --model openai/gpt-5-mini \
+        --preset-name tbench-opencode
 """
 
 import asyncio
+import dataclasses
 
 import ares
 from ares import config
 from ares.llms import chat_completions_compatible
+import simple_parsing
 
 from . import utils
 
 
-async def main():
+@dataclasses.dataclass(frozen=True)
+class Args:
+    model: str = "openai/gpt-5-mini"
+    preset_name: str = "sbv-mswea"
+
+
+async def main(args: Args):
     # Fail fast if env vars aren't set.
     if not config.CONFIG.chat_completion_api_key:
         raise ValueError("CHAT_COMPLETION_API_KEY is not set")
 
     # Create an LLM client using the ChatCompletionCompatibleLLMClient
-    agent = chat_completions_compatible.ChatCompletionCompatibleLLMClient(model="openai/gpt-5-mini")
+    agent = chat_completions_compatible.ChatCompletionCompatibleLLMClient(model=args.model)
 
-    # `sbv-mswea` is SWE-bench Verified with mini-swe-agent.
     # `:0` means load only the first task.
     # By default, ares.make will use local Docker containers.
-    async with ares.make("sbv-mswea:0") as env:
+    async with ares.make(f"{args.preset_name}:0") as env:
         # Reset the environment to get the first timestep
         ts = await env.reset()
         step_count = 0
@@ -61,8 +72,11 @@ async def main():
         print(f"\n{'=' * 80}")
         print(f"Episode completed after {step_count} steps")
         print(f"Total reward: {total_reward}")
+        artifact_dir = getattr(env, "artifact_dir", None)
+        if artifact_dir is not None:
+            print(f"Artifacts: {artifact_dir}")
         print(f"{'=' * 80}")
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(main(simple_parsing.parse(Args, add_option_string_dash_variants=simple_parsing.DashVariant.DASH)))

--- a/integration_tests/opencode_agent_test.py
+++ b/integration_tests/opencode_agent_test.py
@@ -1,0 +1,87 @@
+"""End-to-end OpenCode agent smoke test."""
+
+import dataclasses
+import os
+import pathlib
+
+import pytest
+
+from ares.code_agents import opencode_agent
+from ares.containers import docker
+from ares.llms import request
+from ares.llms import response
+
+
+@dataclasses.dataclass
+class _SmokeTestLLMClient:
+    calls: int = 0
+    title_calls: int = 0
+
+    async def __call__(self, request: request.LLMRequest) -> response.LLMResponse:
+        self.calls += 1
+        has_tool_result = any(message.get("role") == "tool" for message in request.messages)
+        if has_tool_result:
+            return response.LLMResponse(
+                data=[response.TextData(content="The requested file has been created.")],
+                cost=0.0,
+                usage=response.Usage(prompt_tokens=10, generated_tokens=5),
+            )
+
+        tool_names = {tool["name"] for tool in request.tools or []}
+        if not tool_names:
+            self.title_calls += 1
+            return response.LLMResponse(
+                data=[response.TextData(content="Create OpenCode smoke-test file")],
+                cost=0.0,
+                usage=response.Usage(prompt_tokens=10, generated_tokens=5),
+            )
+        if "write" not in tool_names:
+            raise AssertionError(f"OpenCode did not expose its write tool: {sorted(tool_names)}")
+        return response.LLMResponse(
+            data=[response.TextData(content="")],
+            cost=0.0,
+            usage=response.Usage(prompt_tokens=10, generated_tokens=5),
+            tool_calls=[
+                response.ToolCallData(
+                    call_id="call_write_smoke_test",
+                    name="write",
+                    arguments=('{"filePath":"/tmp/ares-opencode-smoke.txt","content":"hello from opencode\\n"}'),
+                )
+            ],
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get("RUN_OPENCODE_INTEGRATION") != "1",
+    reason="Set RUN_OPENCODE_INTEGRATION=1 to install and run OpenCode in Docker.",
+)
+@pytest.mark.asyncio
+async def test_opencode_runs_through_ares_proxy(tmp_path: pathlib.Path) -> None:
+    container = docker.DockerContainer.from_image(image="ubuntu:22.04")
+    await container.start()
+    try:
+        llm_client = _SmokeTestLLMClient()
+        agent = opencode_agent.OpenCodeAgent(container=container, llm_client=llm_client)
+
+        await agent.run("Create /tmp/ares-opencode-smoke.txt containing exactly 'hello from opencode'.")
+
+        result = await container.exec_run("cat /tmp/ares-opencode-smoke.txt")
+        assert result.exit_code == 0
+        assert result.output.strip() == "hello from opencode"
+        assert llm_client.calls >= 2
+        assert llm_client.title_calls == 0
+
+        mediated_log = await container.exec_run("cat /logs/agent/mediated.jsonl")
+        assert mediated_log.exit_code == 0
+        assert '"event":"request"' in mediated_log.output
+        assert '"event":"response"' in mediated_log.output
+        opencode_log = await container.exec_run("cat /logs/agent/opencode.jsonl")
+        assert opencode_log.exit_code == 0
+        assert opencode_log.output.strip()
+
+        artifact_dir = tmp_path / "artifacts"
+        await container.download_dir("/logs", artifact_dir)
+        assert (artifact_dir / "agent" / "opencode.jsonl").is_file()
+        assert (artifact_dir / "agent" / "mediated.jsonl").is_file()
+    finally:
+        await container.stop()

--- a/src/ares/code_agents/opencode_agent.py
+++ b/src/ares/code_agents/opencode_agent.py
@@ -1,0 +1,160 @@
+"""Expose an in-sandbox OpenCode process as an ARES code agent."""
+
+import asyncio
+import contextlib
+import dataclasses
+import json
+import logging
+import pathlib
+import tempfile
+import time
+from typing import Any, cast
+
+import openai.types.responses.response_create_params
+
+from ares.code_agents import ares_proxy
+from ares.code_agents import opencode_cli
+from ares.containers import containers
+from ares.llms import llm_clients
+from ares.llms import openai_responses_converter
+from ares.llms import openai_responses_stream
+from ares.llms import request
+from ares.llms import response
+
+_LOGGER = logging.getLogger(__name__)
+
+_MEDIATED_LOG_PATH = "/logs/agent/mediated.jsonl"
+_POLL_INTERVAL_SECONDS = 0.25
+_TITLE_SYSTEM_FINGERPRINT = "You are a title generator. You output ONLY a thread title."
+_TITLE_USER_SENTINEL = "Generate a title for this conversation:\n"
+
+
+def _to_llm_request(proxy_request: ares_proxy.PendingRequest) -> request.LLMRequest:
+    if proxy_request.endpoint != "/v1/responses":
+        raise ValueError(f"OpenCode must use /v1/responses, got {proxy_request.endpoint!r}")
+    params = dict(proxy_request.request)
+    params.pop("stream", None)
+    return openai_responses_converter.from_external(
+        cast(openai.types.responses.response_create_params.ResponseCreateParamsBase, params),
+        strict=False,
+    )
+
+
+def _is_title_request(llm_request: request.LLMRequest) -> bool:
+    """Identify OpenCode's hidden title request without relying on request order."""
+    user_texts = [message.get("content") for message in llm_request.messages if message.get("role") == "user"]
+    return (
+        _TITLE_SYSTEM_FINGERPRINT in (llm_request.system_prompt or "")
+        and not llm_request.tools
+        and len(user_texts) >= 2
+        and user_texts[0] == _TITLE_USER_SENTINEL
+    )
+
+
+@dataclasses.dataclass(kw_only=True)
+class OpenCodeAgent:
+    """Install and run OpenCode in a sandbox through ares-proxy."""
+
+    container: containers.Container
+    llm_client: llm_clients.LLMClient
+    opencode_version: str = opencode_cli.DEFAULT_VERSION
+    proxy_timeout_minutes: int = 15
+    poll_interval_seconds: float = _POLL_INTERVAL_SECONDS
+
+    def __post_init__(self) -> None:
+        self._proxy = ares_proxy.SandboxProxy(
+            container=self.container,
+            timeout_minutes=self.proxy_timeout_minutes,
+        )
+        self._cli = opencode_cli.OpenCodeCLI(container=self.container, version=self.opencode_version)
+        self._opencode_task: asyncio.Task[None] | None = None
+        self._trajectory: list[dict[str, Any]] = []
+
+    async def run(self, task: str) -> None:
+        try:
+            await self._proxy.install()
+            await self._cli.install()
+            await self._proxy.start()
+            await self._cli.configure(self._proxy.url)
+            self._opencode_task = asyncio.create_task(self._cli.run(task))
+            await self._bridge_requests()
+        finally:
+            try:
+                await self._persist_trajectory()
+            except Exception:
+                _LOGGER.exception("[%d] Failed to persist OpenCode trajectory", id(self))
+            finally:
+                await self._cleanup()
+
+    async def _bridge_requests(self) -> None:
+        assert self._opencode_task is not None
+        while not self._opencode_task.done():
+            pending_requests = await self._proxy.poll()
+            await asyncio.gather(*(self._process_request(value) for value in pending_requests))
+            if not pending_requests:
+                await asyncio.sleep(self.poll_interval_seconds)
+        await self._opencode_task
+
+    async def _process_request(self, proxy_request: ares_proxy.PendingRequest) -> None:
+        llm_request = _to_llm_request(proxy_request)
+        if _is_title_request(llm_request):
+            self._record_trajectory(
+                "request",
+                request_id=proxy_request.id,
+                endpoint=proxy_request.endpoint,
+                filtered="opencode_title",
+                raw_request=proxy_request.request,
+                llm_request=dataclasses.asdict(llm_request),
+            )
+            llm_response = response.LLMResponse(
+                data=[response.TextData(content="ARES evaluation")],
+                cost=0.0,
+                usage=response.Usage(prompt_tokens=0, generated_tokens=0),
+            )
+            filtered = "opencode_title"
+        else:
+            self._record_trajectory(
+                "request",
+                request_id=proxy_request.id,
+                endpoint=proxy_request.endpoint,
+                raw_request=proxy_request.request,
+                llm_request=dataclasses.asdict(llm_request),
+            )
+            llm_response = await self.llm_client(llm_request)
+            filtered = None
+
+        self._record_trajectory(
+            "response",
+            request_id=proxy_request.id,
+            filtered=filtered,
+            response=dataclasses.asdict(llm_response),
+        )
+        model = proxy_request.request.get("model")
+        stream = openai_responses_stream.to_sse(
+            llm_response,
+            model=model if isinstance(model, str) else "ares",
+        )
+        await self._proxy.respond(proxy_request.id, stream, content_type="text/event-stream")
+
+    def _record_trajectory(self, event: str, **values: Any) -> None:
+        self._trajectory.append({"event": event, "timestamp": time.time(), **values})
+
+    async def _persist_trajectory(self) -> None:
+        if not self._trajectory:
+            return
+        with tempfile.TemporaryDirectory(prefix="ares-opencode-trajectory-") as temp_dir:
+            local_path = pathlib.Path(temp_dir) / "mediated.jsonl"
+            local_path.write_text(
+                "".join(json.dumps(record, default=str, separators=(",", ":")) + "\n" for record in self._trajectory)
+            )
+            await self.container.upload_file(local_path, _MEDIATED_LOG_PATH)
+
+    async def _cleanup(self) -> None:
+        await self._cli.stop()
+        await self._proxy.stop()
+        if self._opencode_task is not None:
+            if not self._opencode_task.done():
+                self._opencode_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._opencode_task
+        self._opencode_task = None

--- a/src/ares/code_agents/opencode_agent_test.py
+++ b/src/ares/code_agents/opencode_agent_test.py
@@ -1,0 +1,189 @@
+"""Tests for the in-sandbox OpenCode agent."""
+
+import asyncio
+import dataclasses
+import json
+import pathlib
+import shlex
+
+import pytest
+
+from ares.code_agents import ares_proxy
+from ares.code_agents import opencode_agent
+from ares.containers import containers
+from ares.llms import request
+from ares.llms import response
+from ares.testing import mock_container
+
+
+def _title_request() -> dict:
+    return {
+        "id": "title-request",
+        "endpoint": "/v1/responses",
+        "request": {
+            "model": "ares",
+            "stream": True,
+            "store": False,
+            "input": [
+                {
+                    "role": "developer",
+                    "content": f"{opencode_agent._TITLE_SYSTEM_FINGERPRINT}\n\n<task>Generate a brief title.</task>",
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": opencode_agent._TITLE_USER_SENTINEL}],
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Fix the bug"}],
+                },
+            ],
+        },
+    }
+
+
+def test_title_request_detection_is_content_based() -> None:
+    assert opencode_agent._is_title_request(opencode_agent._to_llm_request(ares_proxy._parse_request(_title_request())))
+
+    first_real_request = _title_request()
+    first_real_request["request"]["input"][0]["content"] = "You are a coding agent."
+    assert not opencode_agent._is_title_request(
+        opencode_agent._to_llm_request(ares_proxy._parse_request(first_real_request))
+    )
+
+
+@pytest.mark.asyncio
+async def test_title_request_is_answered_without_llm_client() -> None:
+    container = _SimulatedOpenCodeContainer()
+    llm_client = _ToolCallingLLMClient()
+    agent = opencode_agent.OpenCodeAgent(container=container, llm_client=llm_client)
+
+    await agent._process_request(ares_proxy._parse_request(_title_request()))
+
+    assert llm_client.requests == []
+    assert container.response_payload is not None
+    assert "ARES evaluation" in container.response_payload["response"]
+    assert agent._trajectory[0]["filtered"] == "opencode_title"
+
+
+@dataclasses.dataclass
+class _SimulatedOpenCodeContainer(mock_container.MockContainer):
+    opencode_started: asyncio.Event = dataclasses.field(default_factory=asyncio.Event)
+    opencode_finished: asyncio.Event = dataclasses.field(default_factory=asyncio.Event)
+    request_polled: bool = False
+    response_payload: dict | None = None
+
+    async def exec_run(
+        self,
+        command: str,
+        *,
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_s: float | None = None,
+    ) -> containers.ExecResult:
+        del workdir, env, timeout_s
+        self.exec_commands.append(command)
+
+        if command == "uname -m":
+            return containers.ExecResult(output="x86_64\n", exit_code=0)
+        if command.startswith("nohup env PORT="):
+            return containers.ExecResult(output="123\n", exit_code=0)
+        if command.startswith("for _ in $(seq 1 50)"):
+            return containers.ExecResult(output="", exit_code=0)
+        if "exec opencode" in command:
+            self.opencode_started.set()
+            await self.opencode_finished.wait()
+            return containers.ExecResult(output="", exit_code=0)
+        if command == "curl -fsS http://localhost:8080/poll":
+            if not self.opencode_started.is_set() or self.request_polled:
+                return containers.ExecResult(output="[]\n", exit_code=0)
+            self.request_polled = True
+            pending = [
+                {
+                    "id": "proxy-request-1",
+                    "endpoint": "/v1/responses",
+                    "timestamp": "2026-08-03T00:00:00Z",
+                    "request": {
+                        "model": "ares",
+                        "stream": True,
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [{"type": "input_text", "text": "Create hello.txt"}],
+                            }
+                        ],
+                        "tools": [
+                            {
+                                "type": "function",
+                                "name": "write",
+                                "description": "Write a file",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {
+                                        "filePath": {"type": "string"},
+                                        "content": {"type": "string"},
+                                    },
+                                },
+                            }
+                        ],
+                    },
+                }
+            ]
+            return containers.ExecResult(output=json.dumps(pending), exit_code=0)
+        if command.startswith("curl -fsS -X POST http://localhost:8080/respond"):
+            parts = shlex.split(command)
+            self.response_payload = json.loads(parts[parts.index("--data-binary") + 1])
+            self.opencode_finished.set()
+            return containers.ExecResult(output='{"status":"ok"}', exit_code=0)
+
+        return containers.ExecResult(output="", exit_code=0)
+
+
+@dataclasses.dataclass
+class _ToolCallingLLMClient:
+    requests: list[request.LLMRequest] = dataclasses.field(default_factory=list)
+
+    async def __call__(self, request: request.LLMRequest) -> response.LLMResponse:
+        self.requests.append(request)
+        return response.LLMResponse(
+            data=[response.TextData(content="")],
+            cost=0.0,
+            usage=response.Usage(prompt_tokens=10, generated_tokens=5),
+            tool_calls=[
+                response.ToolCallData(
+                    call_id="call_write",
+                    name="write",
+                    arguments='{"filePath":"/workspace/hello.txt","content":"hello"}',
+                )
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_opencode_agent_runs_proxy_bridge(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    proxy_binary = tmp_path / "ares-proxy"
+    proxy_binary.write_bytes(b"binary")
+
+    async def get_proxy_binary(goarch: str) -> pathlib.Path:
+        assert goarch == "amd64"
+        return proxy_binary
+
+    monkeypatch.setattr(ares_proxy, "_get_binary", get_proxy_binary)
+    container = _SimulatedOpenCodeContainer()
+    llm_client = _ToolCallingLLMClient()
+    agent = opencode_agent.OpenCodeAgent(
+        container=container,
+        llm_client=llm_client,
+        poll_interval_seconds=0.001,
+    )
+
+    await asyncio.wait_for(agent.run("Create hello.txt"), timeout=2)
+
+    assert container.uploaded_files[0] == (proxy_binary, ares_proxy.PATH)
+    assert container.uploaded_files[-1][1] == "/logs/agent/mediated.jsonl"
+    assert len(llm_client.requests) == 1
+    assert llm_client.requests[0].messages == [{"role": "user", "content": "Create hello.txt"}]
+
+    assert container.response_payload is not None
+    assert container.response_payload["id"] == "proxy-request-1"
+    assert container.response_payload["content_type"] == "text/event-stream"

--- a/src/ares/presets.py
+++ b/src/ares/presets.py
@@ -12,6 +12,7 @@ import collections
 import dataclasses
 import functools
 import logging
+import pathlib
 
 from harbor.models import registry as harbor_registry
 from harbor.models.task import task as harbor_task
@@ -19,6 +20,7 @@ from harbor.models.task import task as harbor_task
 from ares import registry
 from ares.code_agents import code_agent_base
 from ares.code_agents import mini_swe_agent
+from ares.code_agents import opencode_agent
 from ares.code_agents.terminus2 import terminus2_agent
 from ares.containers import containers
 from ares.environments import base
@@ -93,6 +95,7 @@ class HarborSpec:
             code_agent_factory=self.code_agent_factory,
             step_limit=self.step_limit,
             tracker=tracker,
+            artifact_root=pathlib.Path("logs") if self.code_agent_id == "opencode" else None,
         )
 
 
@@ -148,6 +151,7 @@ def _register_default_presets() -> None:
 
         for code_agent_id, code_agent_factory, step_limit in [
             ("mswea", _make_mswea_factory(ds_spec), 0),
+            ("opencode", opencode_agent.OpenCodeAgent, code_env.DEFAULT_STEP_LIMIT),
             ("terminus2", terminus2_agent.Terminus2Agent, code_env.DEFAULT_STEP_LIMIT),
         ]:
             registry.register_preset(


### PR DESCRIPTION
# User description
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expose OpenCode as an ARES code agent by bridging its in-sandbox OpenAI Responses API requests through <code>ares-proxy</code> and the standard evaluation loop. Add preset registration, artifact capture, CLI-selectable models and presets, documentation, and end-to-end coverage for request mediation and tool execution.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/withmartian/ares/116?tool=ast&topic=Preset+usage>Preset usage</a>
        </td><td>Enable users to select an OpenCode preset and model from the sequential API example, document setup and generated logs, and expose artifact locations after evaluation.<details><summary>Modified files (3)</summary><ul><li>README.md</li>
<li>examples/02_sequential_eval_with_api.py</li>
<li>src/ares/presets.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Expose OpenCode agent ...</td><td>August 07, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Use Terminal-Bench Min...</td><td>August 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/withmartian/ares/116?tool=ast&topic=OpenCode+execution>OpenCode execution</a>
        </td><td>Add <code>OpenCodeAgent</code> to install and run OpenCode in task sandboxes, mediate Responses API requests through <code>ares-proxy</code>, filter title generation, stream model responses, and persist trajectory logs and artifacts.<details><summary>Modified files (4)</summary><ul><li>integration_tests/opencode_agent_test.py</li>
<li>src/ares/code_agents/opencode_agent.py</li>
<li>src/ares/code_agents/opencode_agent_test.py</li>
<li>src/ares/presets.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@withmartian.com</td><td>Expose OpenCode agent ...</td><td>August 07, 2026</td></tr>
<tr><td>joshua.greaves@gmail.com</td><td>Use Terminal-Bench Min...</td><td>August 03, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/withmartian/ares/116?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>